### PR TITLE
feat(install): wire cache hooks into settings.json automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Un skill s'exécute *pendant* une session déjà lancée. Il ne peut donc pas d�
 - **Cache local** (`hooks/green-claude-cache.sh`) : une question déjà posée est resservie sans réappeler le modèle, zéro token consommé.
 - **Avertissement heures creuses** (même hook) : signale les heures de pointe (hors 22h-6h UTC) sans bloquer.
 
-Ces hooks se câblent dans `~/.claude/settings.json`. `install.sh` te guide, mais vérifie la doc hooks de ta version de Claude Code avant de coller la config.
+Ces hooks se câblent dans `~/.claude/settings.json`. Si on réponds « o », `install.sh` les y ajoute (les autres réglages sont préservés et une sauvegarde du fichier d'origine est laissée en `settings.json.green-claude.bak`). Sans `jq` il affiche la config à coller à la main. Pour les retirer : supprimer les deux entrées `green-claude-*` du fichier.
 
 ---
 

--- a/hooks/green-claude-cache-save.sh
+++ b/hooks/green-claude-cache-save.sh
@@ -1,25 +1,38 @@
 #!/bin/bash
 # Hook Stop — complète green-claude-cache.sh : sauvegarde la réponse finale
-# dans le cache, indexée par le hash du prompt qui l'a déclenchée.
+# dans le cache, sous la clé que cache.sh a déposée pour cette session.
 #
-# À déclarer dans ~/.claude/settings.json (voir install.sh) :
-#   "hooks": { "Stop": [{"hooks": [{"type": "command", "command": "~/.claude/hooks/green-claude-cache-save.sh"}]}] }
-
+# Le payload du hook Stop ne contient ni le prompt ni la réponse, seulement
+# session_id / transcript_path / stop_hook_active / cwd. La clé vient donc du
+# fichier pending, et la réponse est relue dans le transcript JSONL.
 #
-# NOTE : les noms de champs (.prompt / .response) du payload JSON du hook Stop
-# dépendent de la version de Claude Code — vérifie la doc officielle avant
-# usage réel et ajuste les clés jq ci-dessous en conséquence.
+# Câblé automatiquement par install.sh dans ~/.claude/settings.json.
 
 set -euo pipefail
 
 CACHE_DIR="$HOME/.cache/green-claude"
-mkdir -p "$CACHE_DIR"
-
 INPUT="$(cat)"
-PROMPT="$(echo "$INPUT" | jq -r '.prompt // empty')"
-RESPONSE="$(echo "$INPUT" | jq -r '.response // empty')"
 
-[ -n "$PROMPT" ] && [ -n "$RESPONSE" ] || exit 0
+SESSION="$(printf '%s' "$INPUT" | jq -r '.session_id // empty')"
+TRANSCRIPT="$(printf '%s' "$INPUT" | jq -r '.transcript_path // empty')"
+PENDING="$CACHE_DIR/pending/$SESSION"
 
-KEY="$(echo -n "$PROMPT" | shasum -a 256 | cut -d' ' -f1)"
-echo "$RESPONSE" > "$CACHE_DIR/$KEY"
+# Pas de clé en attente (prompt servi depuis le cache, ou hook lancé seul) :
+# rien à sauvegarder.
+[ -n "$SESSION" ] || exit 0
+[ -f "$PENDING" ] || exit 0
+[ -n "$TRANSCRIPT" ] && [ -r "$TRANSCRIPT" ] || { rm -f "$PENDING"; exit 0; }
+
+# Dernier bloc texte de l'assistant. -s puis last prend le bloc entier : un
+# tail -1 ne garderait que sa dernière ligne. Les blocs thinking et tool_use
+# sont écartés par le select.
+RESPONSE="$(jq -rs '[ .[]
+                      | select(.type == "assistant")
+                      | .message.content[]?
+                      | select(.type == "text")
+                      | .text ] | last // empty' "$TRANSCRIPT" 2>/dev/null || true)"
+
+if [ -n "$RESPONSE" ]; then
+    printf '%s' "$RESPONSE" > "$CACHE_DIR/$(cat "$PENDING")"
+fi
+rm -f "$PENDING"

--- a/hooks/green-claude-cache.sh
+++ b/hooks/green-claude-cache.sh
@@ -14,15 +14,19 @@ OFFPEAK_START=22   # 22h UTC
 OFFPEAK_END=6       # 6h UTC
 mkdir -p "$CACHE_DIR"
 
-PROMPT="$(cat)"
+# Hasher le prompt seul, pas l'enveloppe : session_id & co. varieraient la clé
+# à chaque session et cache-save.sh n'en retrouverait aucune.
+PROMPT="$(jq -r '.prompt // empty')"
+[ -n "$PROMPT" ] || exit 0
 KEY="$(echo -n "$PROMPT" | shasum -a 256 | cut -d' ' -f1)"
 CACHE_FILE="$CACHE_DIR/$KEY"
 
 # 1. Cache : réponse déjà connue pour ce prompt exact -> zéro appel modèle
 if [ -f "$CACHE_FILE" ]; then
-    cat "$CACHE_FILE"
-    # decision "block" empêche l'envoi au modèle et affiche la sortie ci-dessus
-    echo '{"decision": "block", "reason": "Réponse servie depuis le cache local Green Claude (zéro appel modèle)."}'
+    # stdout doit être du JSON seul : la réponse passe par "reason", que
+    # decision "block" affiche à la place de l'appel au modèle.
+    jq -n --rawfile r "$CACHE_FILE" \
+      '{decision: "block", reason: ($r + "\n[Green Claude] Réponse servie depuis le cache local (zéro appel modèle).")}'
     exit 0
 fi
 

--- a/hooks/green-claude-cache.sh
+++ b/hooks/green-claude-cache.sh
@@ -11,7 +11,7 @@ set -euo pipefail
 CACHE_DIR="$HOME/.cache/green-claude"
 OFFPEAK_START=22   # 22h UTC
 OFFPEAK_END=6       # 6h UTC
-TTL_DAYS=7
+TTL_MIN=60
 mkdir -p "$CACHE_DIR/pending"
 
 # Hasher le prompt seul, pas l'enveloppe : session_id & co. varieraient la clé
@@ -21,16 +21,19 @@ PROMPT="$(printf '%s' "$INPUT" | jq -r '.prompt // empty')"
 [ -n "$PROMPT" ] || exit 0
 
 # Le cwd entre dans la clé : le même prompt posé dans deux projets différents
-# n'attend pas la même réponse.
+# n'attend pas la même réponse. Le HEAD git aussi : sans lui, une réponse
+# décrivant le dépôt survit aux commits qui la rendent fausse. Hors dépôt git,
+# la clé retombe sur cwd + prompt.
 CWD="$(printf '%s' "$INPUT" | jq -r '.cwd // empty')"
-KEY="$(printf '%s\n%s' "$CWD" "$PROMPT" | shasum -a 256 | cut -d' ' -f1)"
+HEAD_SHA="$(git -C "${CWD:-.}" rev-parse HEAD 2>/dev/null || true)"
+KEY="$(printf '%s\n%s\n%s' "$CWD" "$HEAD_SHA" "$PROMPT" | shasum -a 256 | cut -d' ' -f1)"
 CACHE_FILE="$CACHE_DIR/$KEY"
 
-# Purge par date de fichier, pas d'index de TTL. Une réponse cachée
-# vieillit mal quand le code qu'elle décrit a changé depuis. La profondeur 2
-# couvre aussi pending/ : une session qui s'arrête sans passer par le hook Stop
-# y laisse une clé que plus personne ne viendra consommer.
-find "$CACHE_DIR" -mindepth 1 -maxdepth 2 -type f -mtime "+$TTL_DAYS" -delete 2>/dev/null || true
+# Purge par date de fichier, pas d'index de TTL : une heure, car une réponse
+# vieillit vite quand le code qu'elle décrit bouge. La profondeur 2 couvre
+# aussi pending/ : une session qui s'arrête sans passer par le hook Stop y
+# laisse une clé que plus personne ne viendra consommer.
+find "$CACHE_DIR" -mindepth 1 -maxdepth 2 -type f -mmin "+$TTL_MIN" -delete 2>/dev/null || true
 
 # 1. Cache : réponse déjà connue pour ce prompt exact -> zéro appel modèle
 if [ -f "$CACHE_FILE" ]; then

--- a/hooks/green-claude-cache.sh
+++ b/hooks/green-claude-cache.sh
@@ -4,22 +4,33 @@
 #   1. Cache local : une question déjà posée est resservie sans appeler l'API.
 #   2. Heures de pointe : avertit avant d'envoyer une requête lourde en journée.
 #
-# À déclarer dans ~/.claude/settings.json (voir install.sh) :
-#   "hooks": { "UserPromptSubmit": [{"hooks": [{"type": "command", "command": "~/.claude/hooks/green-claude-cache.sh"}]}] }
+# Câblé automatiquement par install.sh dans ~/.claude/settings.json.
 
 set -euo pipefail
 
 CACHE_DIR="$HOME/.cache/green-claude"
 OFFPEAK_START=22   # 22h UTC
 OFFPEAK_END=6       # 6h UTC
-mkdir -p "$CACHE_DIR"
+TTL_DAYS=7
+mkdir -p "$CACHE_DIR/pending"
 
 # Hasher le prompt seul, pas l'enveloppe : session_id & co. varieraient la clé
 # à chaque session et cache-save.sh n'en retrouverait aucune.
-PROMPT="$(jq -r '.prompt // empty')"
+INPUT="$(cat)"
+PROMPT="$(printf '%s' "$INPUT" | jq -r '.prompt // empty')"
 [ -n "$PROMPT" ] || exit 0
-KEY="$(echo -n "$PROMPT" | shasum -a 256 | cut -d' ' -f1)"
+
+# Le cwd entre dans la clé : le même prompt posé dans deux projets différents
+# n'attend pas la même réponse.
+CWD="$(printf '%s' "$INPUT" | jq -r '.cwd // empty')"
+KEY="$(printf '%s\n%s' "$CWD" "$PROMPT" | shasum -a 256 | cut -d' ' -f1)"
 CACHE_FILE="$CACHE_DIR/$KEY"
+
+# Purge par date de fichier, pas d'index de TTL. Une réponse cachée
+# vieillit mal quand le code qu'elle décrit a changé depuis. La profondeur 2
+# couvre aussi pending/ : une session qui s'arrête sans passer par le hook Stop
+# y laisse une clé que plus personne ne viendra consommer.
+find "$CACHE_DIR" -mindepth 1 -maxdepth 2 -type f -mtime "+$TTL_DAYS" -delete 2>/dev/null || true
 
 # 1. Cache : réponse déjà connue pour ce prompt exact -> zéro appel modèle
 if [ -f "$CACHE_FILE" ]; then
@@ -28,6 +39,14 @@ if [ -f "$CACHE_FILE" ]; then
     jq -n --rawfile r "$CACHE_FILE" \
       '{decision: "block", reason: ($r + "\n[Green Claude] Réponse servie depuis le cache local (zéro appel modèle).")}'
     exit 0
+fi
+
+# Le payload du hook Stop ne porte ni le prompt ni la réponse : on lui laisse
+# la clé ici, plutôt que de la lui faire recalculer depuis le transcript (tout
+# écart de texte la ferait diverger et le cache ne se remplirait jamais).
+SESSION="$(printf '%s' "$INPUT" | jq -r '.session_id // empty')"
+if [ -n "$SESSION" ]; then
+    printf '%s' "$KEY" > "$CACHE_DIR/pending/$SESSION"
 fi
 
 # 2. Heures de pointe : simple avertissement, ne bloque jamais

--- a/hooks/test-cache.sh
+++ b/hooks/test-cache.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# Vérifie le cycle complet du cache : miss -> sauvegarde -> hit, l'isolation
+# par projet, et la sortie propre quand il n'y a rien à sauvegarder.
+# Lancer : bash hooks/test-cache.sh
+set -euo pipefail
+cd "$(dirname "$0")"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+export HOME="$TMP"          # isole ~/.cache/green-claude
+
+TRANSCRIPT="$TMP/t.jsonl"
+cat > "$TRANSCRIPT" <<'EOF'
+{"type":"assistant","message":{"content":[{"type":"thinking","thinking":"a exclure"}]}}
+{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"x","content":"a exclure"}]}}
+{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Bash","input":{}}]}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"Paris.\nSur deux lignes."}]}}
+EOF
+
+prompt_payload() {  # session, cwd, prompt
+    jq -nc --arg s "$1" --arg t "$TRANSCRIPT" --arg c "$2" --arg p "$3" \
+      '{session_id:$s, transcript_path:$t, cwd:$c, hook_event_name:"UserPromptSubmit", prompt:$p}'
+}
+stop_payload() {    # session, cwd
+    jq -nc --arg s "$1" --arg t "$TRANSCRIPT" --arg c "$2" \
+      '{session_id:$s, transcript_path:$t, cwd:$c, hook_event_name:"Stop", stop_hook_active:false}'
+}
+fail() { echo "ECHEC: $1"; exit 1; }
+CACHE="$HOME/.cache/green-claude"
+
+# 1. Premier passage : rien en cache, aucun blocage, clé déposée pour Stop.
+OUT="$(prompt_payload sess1 /proj/a "capitale de la France" | bash green-claude-cache.sh 2>/dev/null)"
+[ -z "$OUT" ] || fail "1er passage: blocage inattendu -> $OUT"
+[ -f "$CACHE/pending/sess1" ] || fail "1er passage: cle pending non deposee"
+
+# 2. Stop : la réponse du transcript atterrit en cache, le pending est purgé.
+stop_payload sess1 /proj/a | bash green-claude-cache-save.sh
+N="$(find "$CACHE" -maxdepth 1 -type f | wc -l | tr -d ' ')"
+[ "$N" -eq 1 ] || fail "sauvegarde: attendu 1 entree en cache, trouve $N"
+if [ -f "$CACHE/pending/sess1" ]; then fail "sauvegarde: pending non nettoye"; fi
+
+# 3. Même prompt, même projet, autre session : hit franc.
+OUT="$(prompt_payload sess2 /proj/a "capitale de la France" | bash green-claude-cache.sh 2>/dev/null)"
+printf '%s' "$OUT" | jq -e '.decision == "block"' >/dev/null \
+    || fail "2e passage: pas de blocage (stdout doit etre du JSON seul) -> $OUT"
+printf '%s' "$OUT" | jq -e '.reason | startswith("Paris.\nSur deux lignes.")' >/dev/null \
+    || fail "2e passage: reponse multi-lignes tronquee ou polluee"
+
+# 4. Même prompt, autre projet : pas de partage entre cwd.
+OUT="$(prompt_payload sess3 /proj/b "capitale de la France" | bash green-claude-cache.sh 2>/dev/null)"
+[ -z "$OUT" ] || fail "isolation cwd: cache partage entre deux projets"
+
+# 5. Stop sans clé en attente : sortie propre, pas d'erreur.
+stop_payload sessX /proj/a | bash green-claude-cache-save.sh \
+    || fail "Stop sans pending doit sortir proprement"
+
+# 6. Purge : une entrée et un pending plus vieux que le TTL disparaissent, les
+# récents survivent. Une session tuée avant son Stop laisse un pending orphelin
+# qu'aucun autre passage ne viendra nettoyer.
+touch -t 200001010000 "$CACHE/pending/vieux-orphelin" "$CACHE"/[0-9a-f]*
+touch "$CACHE/pending/recent"
+prompt_payload sess4 /proj/c "declenche la purge" | bash green-claude-cache.sh 2>/dev/null >/dev/null
+if [ -f "$CACHE/pending/vieux-orphelin" ]; then fail "purge: pending orphelin non supprime"; fi
+[ -f "$CACHE/pending/recent" ] || fail "purge: pending recent supprime a tort"
+N="$(find "$CACHE" -maxdepth 1 -type f | wc -l | tr -d ' ')"
+[ "$N" -eq 0 ] || fail "purge: entree perimee conservee ($N restante(s))"
+
+echo "OK - 6 verifications passees"

--- a/hooks/test-cache.sh
+++ b/hooks/test-cache.sh
@@ -65,4 +65,23 @@ if [ -f "$CACHE/pending/vieux-orphelin" ]; then fail "purge: pending orphelin no
 N="$(find "$CACHE" -maxdepth 1 -type f | wc -l | tr -d ' ')"
 [ "$N" -eq 0 ] || fail "purge: entree perimee conservee ($N restante(s))"
 
-echo "OK - 6 verifications passees"
+# 7. Le dépôt bouge sous la réponse : même prompt, même projet, mais HEAD
+# différent -> miss. C'est le cas observé en vrai, une réponse decrivant l'état
+# du dépôt resservie après des commits qui la rendaient fausse.
+REPO="$TMP/repo"
+mkdir -p "$REPO"
+git -C "$REPO" init -q
+gitc() { git -C "$REPO" -c user.email=t@t -c user.name=t "$@"; }
+gitc commit -q --allow-empty -m un
+
+prompt_payload sess5 "$REPO" "etat du depot" | bash green-claude-cache.sh >/dev/null 2>&1
+stop_payload sess5 "$REPO" | bash green-claude-cache-save.sh
+OUT="$(prompt_payload sess6 "$REPO" "etat du depot" | bash green-claude-cache.sh 2>/dev/null)"
+printf '%s' "$OUT" | jq -e '.decision == "block"' >/dev/null \
+    || fail "depot inchange: le hit attendu n a pas eu lieu"
+
+gitc commit -q --allow-empty -m deux
+OUT="$(prompt_payload sess7 "$REPO" "etat du depot" | bash green-claude-cache.sh 2>/dev/null)"
+[ -z "$OUT" ] || fail "apres commit: la reponse perimee a ete resservie"
+
+echo "OK - 7 verifications passees"

--- a/install.sh
+++ b/install.sh
@@ -18,6 +18,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SKILLS_DIR="$HOME/.claude/skills/green-claude"
 HOOKS_DIR="$HOME/.claude/hooks"
 SETTINGS_FILE="$HOME/.claude/settings.json"
+CACHE_HOOK="~/.claude/hooks/green-claude-cache.sh"
+SAVE_HOOK="~/.claude/hooks/green-claude-cache-save.sh"
 
 print_error()   { echo -e "${RED}[ERREUR]${NC} $1"; }
 print_success() { echo -e "${GREEN}[OK]${NC} $1"; }
@@ -38,9 +40,12 @@ chmod +x "$SKILLS_DIR/scripts/"*.sh
 print_success "Skill installé"
 
 if ! command -v jq >/dev/null 2>&1; then
-    print_warning "jq n'est pas installé : le script d'audit (scripts/eco-audit.sh) en a besoin."
+    print_warning "jq n'est pas installé : le script d'audit (scripts/eco-audit.sh) et les hooks en ont besoin."
     print_warning "  brew install jq        (macOS)"
     print_warning "  sudo apt install jq    (Debian/Ubuntu)"
+fi
+if ! command -v shasum >/dev/null 2>&1; then
+    print_warning "shasum n'est pas installé : les hooks de cache en ont besoin (paquet perl)."
 fi
 
 # =============================================================================
@@ -57,22 +62,40 @@ if [[ $REPLY =~ ^[OoYy]$ ]]; then
     cp "$SCRIPT_DIR/hooks/green-claude-cache-save.sh" "$HOOKS_DIR/"
     chmod +x "$HOOKS_DIR/green-claude-cache.sh" "$HOOKS_DIR/green-claude-cache-save.sh"
     print_success "Scripts de hook copiés dans $HOOKS_DIR"
-    print_warning "Câblage à faire à la main dans $SETTINGS_FILE (les clés exactes dépendent"
-    print_warning "de ta version de Claude Code — vérifie la doc hooks avant de coller) :"
-    cat << 'EOF'
 
-  {
-    "hooks": {
-      "UserPromptSubmit": [
-        { "hooks": [{ "type": "command", "command": "~/.claude/hooks/green-claude-cache.sh" }] }
-      ],
-      "Stop": [
-        { "hooks": [{ "type": "command", "command": "~/.claude/hooks/green-claude-cache-save.sh" }] }
-      ]
+    # Idempotent : un hook déjà déclaré, sous n'importe quelle forme de chemin,
+    # n'est pas réajouté. Les hooks existants sont préservés.
+    wire_hook() { # $1 = événement, $2 = commande, $3 = fichier source
+        jq --arg e "$1" --arg c "$2" --arg s "/${2##*/}" '
+          if [.. | objects | .command? // empty] | any(. == $c or endswith($s)) then .
+          else .hooks[$e] = ((.hooks[$e] // []) + [{hooks: [{type: "command", command: $c}]}])
+          end' "$3"
     }
-  }
 
-EOF
+    WIRED=0
+    if command -v jq >/dev/null 2>&1; then
+        [ -s "$SETTINGS_FILE" ] || echo '{}' > "$SETTINGS_FILE"
+        # Écriture atomique : le fichier n'est remplacé que si jq a réussi.
+        TMP="$(mktemp)"
+        if wire_hook "UserPromptSubmit" "$CACHE_HOOK" "$SETTINGS_FILE" > "$TMP" \
+           && wire_hook "Stop" "$SAVE_HOOK" "$TMP" > "$TMP.2" \
+           && [ -s "$TMP.2" ]; then
+            # État d'origine seulement : une réinstallation ne l'écrase pas.
+            [ -f "$SETTINGS_FILE.green-claude.bak" ] || cp "$SETTINGS_FILE" "$SETTINGS_FILE.green-claude.bak"
+            mv "$TMP.2" "$SETTINGS_FILE"
+            WIRED=1
+            print_success "Hooks câblés dans $SETTINGS_FILE (sauvegarde : $SETTINGS_FILE.green-claude.bak)"
+            print_info "Redémarre Claude Code pour les activer."
+        else
+            print_error "jq n'a pas pu traiter $SETTINGS_FILE, fichier laissé intact."
+        fi
+        rm -f "$TMP" "$TMP.2"
+    fi
+
+    if [ "$WIRED" -eq 0 ]; then
+        print_warning "Câblage à faire à la main dans $SETTINGS_FILE :"
+        printf '\n  {\n    "hooks": {\n      "UserPromptSubmit": [\n        { "hooks": [{ "type": "command", "command": "%s" }] }\n      ],\n      "Stop": [\n        { "hooks": [{ "type": "command", "command": "%s" }] }\n      ]\n    }\n  }\n\n' "$CACHE_HOOK" "$SAVE_HOOK"
+    fi
 else
     print_info "Hook ignoré — installable plus tard depuis $SCRIPT_DIR/hooks/"
 fi


### PR DESCRIPTION
Avant, `install.sh` copiait les hooks puis laissait coller le JSON à la main dans `~/.claude/settings.json`. Maintenant il le fait automatiquement. Et le cache, qui n'avait jamais pu resservir la moindre réponse, marche pour de bon.

## Le câblage (`install.sh`)

Une fonction `wire_hook` ajoute les entrées avec `jq` :

- **Idempotent :** relancer l'install ne crée pas de doublon même si le hook avait été déclaré en chemin absolu au lieu de `~/...`.
- **Non destructif :** les autres réglages sont préservés et l'état d'origine est sauvegardé en `settings.json.green-claude.bak` (une réinstall ne l'écrase pas).
- **Atomique :** `jq` écrit dans un temp, le `mv` n'a lieu que si ça a marché. Avant, une simple virgule traînante dans `settings.json` suffisait à le vider, la redirection le tronquait à 0 octet avant même que `jq` démarre.
- **Repli :** pas de `jq`, ou `jq` qui échoue, on affiche le bloc à coller comme avant sans toucher au fichier.

## Le cache (`hooks/`)

Trois bugs l'empêchaient de tourner, chacun suffisant à lui seul.

- La clé était le SHA de tout le payload stdin (`session_id`, `cwd`...) alors que `cache-save.sh` indexe sur `.prompt` seul. Les deux clés ne pouvaient jamais tomber pareil donc le cache se remplissait sans jamais rien resservir. On extrait `.prompt` maintenant.
- Sur un hit, le hook sortait le texte **puis** son JSON `{"decision":"block"}` sur le même flux. Ça ne parse pas donc le blocage ne s'appliquait pas. La réponse passe par `reason` via `jq -n --rawfile`.
- `cache-save.sh` lisait `.prompt` et `.response`, absents du payload du hook `Stop` qui ne porte que `session_id`, `transcript_path`, `stop_hook_active` et `cwd`. Il sortait donc toujours sans rien écrire, et le cache restait vide même une fois les deux bugs du dessus corrigés. Il relit maintenant la dernière réponse dans le JSONL de `transcript_path`.

Recalculer la clé depuis le transcript l'aurait fait diverger de celle hashée sur `.prompt` au moindre écart de texte. `cache.sh` dépose donc la clé dans `pending/$session_id` et `cache-save.sh` la relit, sans jamais la recalculer.

### Ce qui entre dans la clé

- **Le `cwd` :** le même prompt posé dans deux projets n'attend pas la même réponse.
- **Le `HEAD` git :** sans lui, une réponse qui décrit le dépôt survit aux commits qui la rendent fausse. Vu en vrai sur cette branche, une réponse resservie annonçait encore `test-cache.sh` à 5 cas alors qu'il était passé à 6 entre-temps. Hors dépôt git, la clé retombe sur `cwd` + prompt.

Les entrées de plus d'une heure sont purgées, `pending/` compris : une session qui s'arrête sans passer par `Stop` y laisse une clé que plus personne ne viendra consommer.

## Testé

`jq empty` sur les règles et `eco-audit.sh` passent. Le câblage sur un `HOME` jetable :

| Cas | Résultat |
|---|---|
| virgule traînante dans le JSON | fichier intact, repli affiché |
| `.hooks.Stop` en objet au lieu d'un tableau | fichier intact |
| `settings.json` vide | câblé |
| deuxième run | identique, hook existant préservé |
| hook déjà là en chemin absolu | une seule entrée |
| réinstall | `.bak` d'origine gardé |

Et `hooks/test-cache.sh` couvre le cycle du cache, sur un `HOME` jetable lui aussi :

| Cas | Résultat |
|---|---|
| premier passage | pas de blocage, clé déposée pour `Stop` |
| hook `Stop` | réponse du transcript écrite, `pending` nettoyé |
| même prompt, autre `session_id` | hit, JSON valide, réponse multi-lignes non tronquée |
| même prompt, autre projet | miss |
| `Stop` sans clé en attente | sortie propre |
| entrée et `pending` périmés | supprimés, les récents gardés |
| même prompt après un commit | miss |

Les deux derniers ont été rejoués contre le code d'avant pour vérifier qu'ils échouent bien là où ils doivent.
