### PR TITLE
Corrige la détection des boucles imbriquées dans l'audit éco-conception

### DIFF
--- a/skill/green-claude/rules/ecoconception.json
+++ b/skill/green-claude/rules/ecoconception.json
@@ -11,7 +11,7 @@
     "coverage_note": "Le RGESN 2024 compte 78 critères en 9 familles ; le GR491 compte 61 recommandations et 516 critères en 8 familles. Ce fichier sélectionne 35 règles actionnables sans reproduire le référentiel complet : chaque famille RGESN est représentée, et le champ rgesn_ref renvoie au critère officiel pour approfondir. rgesn_ref au format 'N.x' signifie que la règle relève de la famille N sans correspondre à un critère unique.",
     "count": 35,
     "type": "code_audit",
-    "type_note": "Les règles avec 'patterns' sont détectées dans le code par l'audit --eco-check. Celles sans pattern sont des règles de conception/processus : elles servent de checklist via --list-rules."
+    "type_note": "Les règles avec 'patterns' sont détectées dans le code par l'audit (grep). Les règles avec 'detector' utilisent un détecteur dédié multi-lignes (scripts/detect-*.awk) quand grep ligne-par-ligne ne suffit pas. Celles sans pattern ni detector sont des règles de conception/processus : elles servent de checklist via --list-rules."
   },
   "categories": {
     "strategie": {
@@ -488,11 +488,9 @@
           "title": "Maîtriser la complexité algorithmique",
           "description": "Deux boucles imbriquées sur n éléments = n² itérations : ce qui passe sur 100 éléments s'effondre sur 100 000.",
           "impact": "Élevé",
-          "patterns": [
-            "for.*\\{.*for",
-            "while.*\\{.*for",
-            "\\.forEach.*\\.forEach"
-          ],
+          "patterns": [],
+          "detector": "nested_loops",
+          "detector_note": "Une imbrication s'étale sur plusieurs lignes : indétectable par grep ligne-par-ligne. Le script scripts/detect-nested-loops.awk suit la profondeur des accolades et signale les boucles internes candidates (à confirmer en contexte : une imbrication n'est pas toujours O(n²) évitable).",
           "recommendation": "Utiliser des structures adaptées (tables de hachage, ensembles) pour ramener la complexité à O(n).",
           "rgesn_ref": "7.x",
           "gr491_famille": "Back-end",

--- a/skill/green-claude/scripts/detect-nested-loops.awk
+++ b/skill/green-claude/scripts/detect-nested-loops.awk
@@ -1,0 +1,43 @@
+# Détecteur de boucles imbriquées (ECO-BACK-03) — heuristique multi-lignes.
+# grep ligne-par-ligne ne peut pas voir une imbrication répartie sur plusieurs
+# lignes ; ici on suit la profondeur des accolades pour savoir si une boucle
+# s'ouvre à l'intérieur du bloc d'une autre.
+#
+# Sortie : "numéro_de_ligne:ligne" pour chaque boucle interne candidate.
+# Heuristique assumée (langages à accolades ; ignore chaînes/commentaires) :
+# c'est un détecteur de CANDIDATS, à confirmer en contexte.
+
+BEGIN { depth = 0; loops = 0; pending = 0; pending_age = 0 }
+
+{
+    line = $0
+    is_loop = (line ~ /(^|[^[:alnum:]_.])(for|while)[[:space:]]*\(/ \
+            || line ~ /\.(forEach|map|flatMap|filter)[[:space:]]*\(/)
+
+    if (is_loop) {
+        # Une boucle qui démarre alors qu'on est déjà dans le bloc d'une
+        # autre boucle = imbrication.
+        if (loops > 0) printf "%d:%s\n", NR, line
+        pending++
+        pending_age = 0
+    }
+
+    n = length(line)
+    for (i = 1; i <= n; i++) {
+        c = substr(line, i, 1)
+        if (c == "{") {
+            depth++
+            if (pending > 0) { loops++; loop_depth[loops] = depth; pending-- }
+        } else if (c == "}") {
+            if (loops > 0 && loop_depth[loops] == depth) loops--
+            depth--
+        }
+    }
+
+    # Boucle sans accolade ouvrante sur sa ligne ni la suivante :
+    # instruction unique (for (...) x++;) — on ne la suit pas.
+    if (pending > 0) {
+        pending_age++
+        if (pending_age > 1) { pending = 0; pending_age = 0 }
+    }
+}

--- a/skill/green-claude/scripts/eco-audit.sh
+++ b/skill/green-claude/scripts/eco-audit.sh
@@ -21,7 +21,7 @@ if [ "${1:-}" = "--list-rules" ]; then
     jq -r '
         [.categories[] as $c | $c.rules[] | . + {category: $c.name}]
         | .[]
-        | select((.patterns // []) | length == 0)
+        | select(((.patterns // []) | length == 0) and ((.detector // "") == ""))
         | "[\(.impact)] \(.id) — \(.title)\n  \(.recommendation)\n"' "$RULES_FILE"
     echo "=== Pratiques d'usage Boris Cherny (contexte, brief, mémoire, vérification, compute) ==="
     jq -r '
@@ -48,14 +48,28 @@ while IFS= read -r rule_json; do
     title=$(jq -r '.title' <<<"$rule_json")
     impact=$(jq -r '.impact' <<<"$rule_json")
     patterns=$(jq -r '.patterns | join("|")' <<<"$rule_json")
+    detector=$(jq -r '.detector // ""' <<<"$rule_json")
     recommendation=$(jq -r '.recommendation' <<<"$rule_json")
     rgesn_ref=$(jq -r '.rgesn_ref' <<<"$rule_json")
 
     for file in "$@"; do
         [ -f "$file" ] || continue
-        if grep -qiE "$patterns" "$file" 2>/dev/null; then
+        matches=""
+        if [ -n "$detector" ]; then
+            # Détecteur dédié multi-lignes (grep ligne-par-ligne ne sait pas
+            # voir une imbrication répartie sur plusieurs lignes).
+            detector_script="$SCRIPT_DIR/detect-$(echo "$detector" | tr '_' '-').awk"
+            [ -f "$detector_script" ] || continue
+            matches=$(awk -f "$detector_script" "$file" 2>/dev/null || true)
+        elif [ -n "$patterns" ]; then
+            matches=$(grep -qiE "$patterns" "$file" 2>/dev/null && echo "match" || true)
+        fi
+        if [ -n "$matches" ]; then
             echo "[$impact] $id — $title"
             echo "  Fichier        : $file"
+            if [ "$matches" != "match" ]; then
+                echo "$matches" | head -5 | sed 's/^/  Ligne          : /'
+            fi
             echo "  Catégorie      : $category"
             echo "  RGESN          : $rgesn_ref"
             echo "  Recommandation : $recommendation"
@@ -66,7 +80,7 @@ while IFS= read -r rule_json; do
 done < <(jq -c '
     [.categories[] as $c | $c.rules[] | . + {category: $c.name}]
     | .[]
-    | select((.patterns // []) | length > 0)' "$RULES_FILE")
+    | select(((.patterns // []) | length > 0) or ((.detector // "") != ""))' "$RULES_FILE")
 
 if [ "$issues_found" -eq 0 ]; then
     echo "Aucune issue d'éco-conception détectée sur les fichiers analysés."


### PR DESCRIPTION
## Le problème

La règle `ECO-BACK-03` (« Maîtriser la complexité algorithmique ») s'appuyait sur des patterns grep du type `for.*\{.*for` pour repérer les boucles imbriquées dans le code.

Le souci : `grep` travaille ligne par ligne, alors qu'une boucle imbriquée s'écrit presque toujours sur plusieurs lignes, par exemple :

```js
for (const user of users) {
  for (const order of user.orders) {
    total += order.amount;
  }
}
```

En pratique, cette règle ne détectait donc jamais rien. Vérifié sur plusieurs cas concrets (`for` dans `for`, `while` dans `for`, `.forEach` dans `.forEach`) : aucun n'était repéré par l'audit, alors que c'est justement le cas d'usage principal de la règle.

## La correction

Remplacement des patterns grep par un petit détecteur dédié (`scripts/detect-nested-loops.awk`) qui suit la profondeur des accolades ligne après ligne : si une boucle s'ouvre alors qu'on est déjà à l'intérieur du bloc d'une autre boucle, elle est signalée avec son numéro de ligne. Deux boucles simplement consécutives, ou une boucle contenant un `if`, ne déclenchent rien.

`eco-audit.sh` gagne un champ `detector` en plus de `patterns` dans les règles : quand une règle en définit un, le script délègue à l'awk correspondant au lieu du grep habituel. La sortie affiche aussi désormais la ligne concernée pour ce type de règle, pour que le rapport soit directement exploitable.

## Tests effectués

| Cas | Attendu | Résultat |
|---|---|---|
| `for` dans `for` (multi-lignes) | détecté | ✅ |
| `while` dans `for` | détecté | ✅ |
| `.forEach` dans `.forEach` | détecté | ✅ |
| Deux boucles séquentielles (pas imbriquées) | rien | ✅ |
| Boucle simple avec `if` à l'intérieur | rien | ✅ |
| Règles grep existantes (autres que ECO-BACK-03) | inchangées | ✅ |

`--list-rules` a aussi été mis à jour pour ne plus lister `ECO-BACK-03` parmi les règles "sans pattern détectable", puisqu'elle l'est de nouveau via son détecteur dédié.