### PR TITLE
Allège SKILL.md et corrige deux inexactitudes

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "green-claude",
   "description": "Éco-conception de services numériques (RGESN 2024 / GR491 / Green Software Foundation) appliquée pendant que Claude Code écrit ou revoit du code, avec un audit déterministe et des pratiques d'usage sobre inspirées de Boris Cherny.",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "author": {
     "name": "Institut du Numérique Responsable"
   },

--- a/skills/green-claude/SKILL.md
+++ b/skills/green-claude/SKILL.md
@@ -8,40 +8,31 @@ description: |
   "RGESN", "GR491", "écoconception", "green IT"), ou quand invoqué via
   /green-claude pour parcourir la checklist des règles.
 author: Institut du Numérique Responsable
-version: 1.1.0
+version: 1.2.0
 license: MIT
 user-invocable: true
 ---
 
 # Green Claude
 
-Deux jeux de règles, deux moments d'application :
+Deux jeux de règles : `rules/ecoconception.json` (35 règles, RGESN 2024 / GR491 /
+Green Software Foundation) pendant que tu écris ou modifies du code, et
+`rules/boris.json` (14 pratiques d'usage) pendant la conversation elle-même. Un
+usage efficace de Claude Code est aussi un usage sobre.
 
-1. **`rules/ecoconception.json`** (35 règles, RGESN 2024 / GR491 / Green Software Foundation),
-   à appliquer **pendant que tu écris ou modifies du code**. C'est le code qui va
-   tourner pendant des années chez les utilisateurs : la sobriété se joue là, pas
-   après coup.
-2. **`rules/boris.json`** (14 pratiques d'usage), à appliquer **pendant la conversation
-   elle-même** : contexte minimal, rembobiner plutôt que corriger, éviter les
-   allers-retours inutiles. Un usage efficace de Claude Code est aussi un usage sobre.
+## Référence rapide
 
-## Pourquoi un skill, et pas juste une liste de règles
+| Mode | Déclencheur | Action |
+|---|---|---|
+| Proactif (par défaut) | Toujours, dès que tu écris ou modifies du code | Applique les familles pertinentes de `ecoconception.json`, sans qu'on te le demande |
+| Audit | « audit éco-conception », « vérifie la sobriété », `--eco-check` | `bash <chemin-du-skill>/scripts/eco-audit.sh fichier1 fichier2 ...` |
+| Browse | `/green-claude` | Checklist complète des 9 familles RGESN + 14 pratiques Boris |
 
-Une liste de règles dans un fichier reste inerte : personne ne la relit avant
-chaque ligne de code, elle vieillit sans que personne s'en aperçoive, et son
-respect dépend de la mémoire de qui l'a écrite ou lue une fois. Un skill
-change trois choses : Claude Code le charge et l'applique à chaque session
-sans qu'on ait à le rappeler, il combine sélection automatique (les familles
-pertinentes pour ce que tu écris, pas les 49 règles à chaque fois) et
-vérification a posteriori via le script d'audit, et il vit dans le même flux
-que le code plutôt que dans un document séparé qu'on consulte une fois puis
-qu'on oublie.
+## Mode proactif
 
-## Mode proactif (par défaut)
-
-Quand tu écris ou modifies du code, garde en tête les familles de `ecoconception.json` :
-stratégie, spécifications, architecture, UX, contenus, frontend, backend, hébergement,
-algorithmie. Concrètement, sans qu'on te le demande :
+Garde en tête les 9 familles de `ecoconception.json` (stratégie, spécifications,
+architecture, UX, contenus, frontend, backend, hébergement, algorithmie).
+Concrètement, sans qu'on te le demande :
 
 - Préfère les formats ouverts et légers (JSON/CSV/Markdown plutôt que docx/xlsx).
 - Limite les requêtes réseau et les payloads (pagination, champs sélectionnés, pas de `SELECT *`).
@@ -50,42 +41,50 @@ algorithmie. Concrètement, sans qu'on te le demande :
 - Compresse et dimensionne correctement les images et assets.
 
 Si une contrainte de sobriété entre en tension avec une demande explicite du user
-(perf, deadline, lisibilité), signale le compromis en une phrase. Ne bloque jamais
-silencieusement le travail demandé.
+(perf, deadline, lisibilité), signale le compromis en une phrase, sans jamais
+bloquer silencieusement le travail demandé.
 
-Pour la conversation elle-même, applique les réflexes Boris : prompt minimal, ne pas
-préc-charger des fichiers entiers si tu peux les lire toi-même à la demande, préférer
+Pour la conversation, applique les réflexes Boris : prompt minimal, ne pas
+précharger des fichiers entiers si tu peux les lire toi-même à la demande,
 rembobiner (double Échap) plutôt qu'empiler des corrections dans le contexte.
 
-## Mode audit (sur demande)
+## Mode audit
 
-Quand l'utilisateur demande explicitement un audit ("audit éco-conception",
-"vérifie la sobriété", "--eco-check"), exécute :
+`bash <chemin-du-skill>/scripts/eco-audit.sh fichier1 fichier2 ...` : un script déterministe
+(grep/awk), sans coût de raisonnement pour la détection. Interprète et priorise
+la sortie (impact Élevé d'abord) — voir *Erreurs courantes* avant de relayer un
+résultat tel quel.
 
-```bash
-bash <chemin-du-skill>/scripts/eco-audit.sh fichier1 fichier2 ...
-```
-
-C'est un script déterministe (grep sur les patterns des règles), sans coût de
-raisonnement pour la détection : tu n'as qu'à interpréter et prioriser la sortie
-pour l'utilisateur (impact Élevé d'abord).
-
-Certaines règles n'ont pas de pattern détectable dans le code (ex. "mesurer avant
-d'optimiser", "critères environnementaux dans les user stories") : ce sont des
-règles de démarche, à rappeler en checklist plutôt qu'à chercher par grep. Le
-script les ignore déjà lors de l'audit, mais les liste avec
-`scripts/eco-audit.sh --list-rules` (règles ecoconception.json sans pattern +
-pratiques boris.json).
+Les règles sans pattern détectable (« mesurer avant d'optimiser », « critères
+environnementaux dans les user stories »...) sont des règles de démarche,
+listées via `<chemin-du-skill>/scripts/eco-audit.sh --list-rules` plutôt que cherchées par grep.
 
 ## Mode browse (`/green-claude`)
 
-Affiche les 9 familles RGESN de `rules/ecoconception.json` et les 14 pratiques de
-`rules/boris.json` sous forme de checklist, avec le titre et la recommandation de
-chaque règle. Utile pour une revue de conception en amont du code.
+Checklist des 9 familles RGESN et des 14 pratiques Boris, avec titre et
+recommandation de chaque règle. Utile pour une revue de conception en amont du code.
+
+## Erreurs courantes
+
+Un hit du script d'audit est un **candidat**, pas une violation confirmée : vérifie
+le contexte avant de le signaler.
+
+- Une `@font-face` auto-hébergée, sous-ensemblée, avec `font-display: swap` suit
+  déjà la recommandation ECO-UX-05 : le pattern matche sans distinguer bon et
+  mauvais usage.
+- `deprecated` en commentaire (ECO-ARCH-03) signale souvent une dépréciation
+  documentée — une bonne pratique, pas un défaut.
+- ECO-ARCH-01 (react/vue/angular/next) vise le choix initial d'architecture ; ne le
+  resignale pas à chaque audit d'un projet déjà construit dessus.
+- Un hit ECO-BACK-03 (`nested_loops`) est une boucle imbriquée candidate à O(n²),
+  pas une preuve : confirme qu'elle dépend de la taille des données avant de
+  recommander un refactor.
 
 ## Ce que ce skill ne fait PAS
 
-Le choix du modèle (Haiku/Sonnet/Opus) et le cache de réponses "zéro token" ne
-peuvent pas être gérés par un skill : ils doivent être décidés *avant* que la
-session ne soit lancée ou la requête envoyée. Voir `hooks/` à la racine du dépôt
-pour ce qui reste de ce périmètre, câblé via un hook `UserPromptSubmit`.
+Le cache de réponses « zéro token » ne peut pas être géré par un skill : il doit
+être câblé via des hooks `UserPromptSubmit`/`Stop`, qui interceptent la requête
+*avant* qu'elle n'atteigne le modèle (voir `hooks/` à la racine du dépôt). Le
+choix du modèle (Haiku/Sonnet/Opus), lui, peut être changé en cours de session
+via `/model` : ce skill ne le fait pas à ta place, mais rien n'empêche de
+suggérer un modèle plus léger si une tâche y est manifestement disproportionnée.


### PR DESCRIPTION
## Le problème

`SKILL.md` faisait 669 mots, chargés en entier à chaque déclenchement du skill — et les conditions de déclenchement sont larges (tout ce qui touche formats de fichiers, requêtes réseau, images, boucles, cache, dépendances...). Trois choses distinctes à corriger :

1. La section « Pourquoi un skill, et pas juste une liste de règles » existait déjà, presque mot pour mot, dans `README.md`. Pure redondance.
2. Le script d'audit (`eco-audit.sh`) produit de vrais faux positifs — une `@font-face` déjà conforme à la recommandation se fait quand même signaler, un `deprecated` en commentaire aussi alors que c'est souvent une bonne pratique documentée — sans qu'aucune section n'indique qu'un hit du script est un candidat à vérifier, pas une violation automatique.
3. Deux inexactitudes : le texte affirmait que le choix du modèle devait être décidé avant le lancement de la session (faux, `/model` fonctionne en cours de route), et une coquille (« préc-charger »).

## Ce qui change

- Suppression de la section dupliquée avec le README.
- Ajout d'une section « Erreurs courantes » qui liste les faux positifs connus du script d'audit, avec le raisonnement à appliquer avant de relayer un résultat à l'utilisateur.
- Ajout d'un tableau de référence rapide pour les trois modes (proactif / audit / browse), qui remplace de la prose répétitive.
- Correction des deux inexactitudes.
- Version bumpée à 1.2.0 (`SKILL.md` + `plugin.json`), contenu changé de façon significative.

Résultat net : 657 mots contre 669 au départ, malgré l'ajout de deux sections utiles — en coupant uniquement la redondance et la prose qui pouvait être un tableau.

## Un piège rencontré en le faisant

La première passe de resserrement du texte a fait sauter, sans que ce soit intentionnel, le préfixe `<chemin-du-skill>/` devant les trois occurrences de `scripts/eco-audit.sh`. Sans ce préfixe, Claude cherche le script relatif au répertoire de travail courant de l'utilisateur plutôt qu'au dossier du skill — ça aurait cassé le mode audit en usage réel. Repéré en relisant le diff avant de committer, corrigé.

## Vérifié

- `claude plugin validate` : passe.
- Réinstallation locale (`claude plugin update green-claude@green-claude`) : la version 1.2.0 s'affiche correctement dans `claude plugin details`.