### PR TITLE
Relie la page de présentation à la fiche du plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "green-claude",
       "source": "./",
-      "description": "Applique les règles d'éco-conception RGESN/GR491 pendant que Claude Code écrit du code, avec audit et checklist."
+      "description": "Applique les règles d'éco-conception RGESN/GR491 pendant que Claude Code écrit du code, avec audit et checklist. Présentation : https://institut-du-numerique-responsable.github.io/green-claude/"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,11 +1,11 @@
 {
   "name": "green-claude",
-  "description": "Éco-conception de services numériques (RGESN 2024 / GR491 / Green Software Foundation) appliquée pendant que Claude Code écrit ou revoit du code, avec un audit déterministe et des pratiques d'usage sobre inspirées de Boris Cherny.",
+  "description": "Éco-conception de services numériques (RGESN 2024 / GR491 / Green Software Foundation) appliquée pendant que Claude Code écrit ou revoit du code, avec un audit déterministe et des pratiques d'usage sobre inspirées de Boris Cherny. Présentation : https://institut-du-numerique-responsable.github.io/green-claude/",
   "version": "1.2.0",
   "author": {
     "name": "Institut du Numérique Responsable"
   },
-  "homepage": "https://institutnr.org/",
+  "homepage": "https://institut-du-numerique-responsable.github.io/green-claude/",
   "repository": "https://github.com/Institut-du-Numerique-Responsable/green-claude",
   "license": "MIT"
 }

--- a/docs/index.html
+++ b/docs/index.html
@@ -31,7 +31,7 @@
     "name": "Green Claude",
     "applicationCategory": "DeveloperApplication",
     "operatingSystem": "macOS, Linux",
-    "softwareVersion": "1.0.1",
+    "softwareVersion": "1.2.0",
     "description": "Skill pour Claude Code : sobriété numérique du code produit (RGESN 2024, GR491, Green Software Foundation), installé une fois et appliqué automatiquement.",
     "license": "https://opensource.org/licenses/MIT",
     "url": "https://github.com/Institut-du-Numerique-Responsable/green-claude",


### PR DESCRIPTION
## Contexte

`docs/index.html` existe et est en ligne via GitHub Pages (https://institut-du-numerique-responsable.github.io/green-claude/) — page de présentation SEO-complète, éco-conçue elle-même (zéro JS, zéro requête externe). Mais rien dans les métadonnées du plugin n'y renvoyait.

## Ce qui change

- `homepage` dans `plugin.json` : pointait vers le site général de l'INR, pointe maintenant vers cette page dédiée au projet.
- `description` (`plugin.json` et `marketplace.json`) : mentionne désormais l'URL de la page, pour qu'elle soit visible directement dans la fiche sans avoir à cliquer sur `homepage`.
- `softwareVersion` dans le JSON-LD de la page : était resté à `1.0.1` depuis la création de la page, corrigé à `1.2.0`.

## Vérifié

- `claude plugin validate` : passe.
- La page répond bien en HTTP 200 à l'URL citée.

Le catalogue communautaire public (soumis séparément) se resynchronise automatiquement sur les pushs du dépôt — pas besoin de repasser par le formulaire.