### PR TITLE
Corrige des affirmations fausses sur la page et le README

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ L'audit (`skills/green-claude/scripts/eco-audit.sh`) est un script déterministe
 | 1. Stratégie | 3 | Mesurer avant d'optimiser, données raisonnées, formats ouverts |
 | 2. Spécifications | 5 | Compatibilité anciens terminaux, bas débit, impact des services tiers |
 | 3. Architecture | 4 | Low-tech d'abord, ressources adaptées à la charge, environnements de test sobres |
-| 4. UX/UI | 5 | Pas d'autoplay ni de scroll infini, composants natifs, polices limitées |
-| 5. Contenus | 3 | Images optimisées, média le plus sobre, SVG |
+| 4. UX/UI | 6 | Pas d'autoplay ni de scroll infini, composants natifs, polices limitées, média le plus sobre |
+| 5. Contenus | 2 | Images optimisées, SVG |
 | 6. Frontend | 4 | Pas de bibliothèque lourde, lazy loading, minification, dépendances |
 | 7. Backend | 4 | SQL optimisé, pools de connexions, complexité, pagination + cache |
 | 8. Hébergement | 3 | Hébergeur sobre, compression HTTP, cache HTTP |

--- a/docs/index.html
+++ b/docs/index.html
@@ -31,7 +31,7 @@
     "name": "Green Claude",
     "applicationCategory": "DeveloperApplication",
     "operatingSystem": "macOS, Linux",
-    "softwareVersion": "1.2.0",
+    "softwareVersion": "1.2.1",
     "description": "Skill pour Claude Code : sobriété numérique du code produit (RGESN 2024, GR491, Green Software Foundation), installé une fois et appliqué automatiquement.",
     "license": "https://opensource.org/licenses/MIT",
     "url": "https://github.com/Institut-du-Numerique-Responsable/green-claude",
@@ -130,9 +130,12 @@
   </div>
 
   <h2>En 30 secondes</h2>
+  <pre><code>/plugin marketplace add Institut-du-Numerique-Responsable/green-claude
+/plugin install green-claude@green-claude</code></pre>
+  <p>Rien d'autre à faire : Claude Code charge le skill automatiquement dans les sessions suivantes et gère ses mises à jour. Tape <code>/green-claude</code> pour voir la checklist complète.</p>
+  <p>Alternative via <code>install.sh</code> (nécessaire pour câbler en plus le hook de cache local) :</p>
   <pre><code>git clone https://github.com/Institut-du-Numerique-Responsable/green-claude.git
 cd green-claude && ./install.sh</code></pre>
-  <p>Le skill s'installe dans <code>~/.claude/skills/green-claude</code> et se charge automatiquement dans les sessions Claude Code suivantes. Rien à taper ensuite. Tape <code>/green-claude</code> pour voir la checklist complète.</p>
 
   <h2>Ce que contient le projet</h2>
   <ul>
@@ -150,7 +153,7 @@ cd green-claude && ./install.sh</code></pre>
 
   <footer>
     <p>Une production de l'<strong>Institut du Numérique Responsable</strong>, 2026, open source (MIT).<br>
-    Cette page applique les règles qu'elle promeut : zéro JavaScript, zéro requête externe, polices système, mode sombre natif, moins de 8 Ko au total.</p>
+    Cette page applique les règles qu'elle promeut : polices système, mode sombre natif, aucune bibliothèque de mise en page. Seule exception : une mesure d'audience légère et auto-hébergée (Matomo).</p>
   </footer>
 </main>
 </body>


### PR DESCRIPTION
## Contexte

Audit complet du dépôt : validations JSON/plugin, tests, et relecture attentive de tout le contenu affiché (README, docs/index.html). Cinq écarts trouvés entre ce que le projet affirme et son état réel.

## Ce qui change

- **`docs/index.html`, pied de page** : revendiquait « zéro JavaScript, zéro requête externe » — faux depuis l'ajout de Matomo (`8384bfa`), qui est un script tiers effectuant une requête externe. Reformulé pour citer Matomo comme seule exception, plutôt que de garder une affirmation qui ne tient plus.
- **« Moins de 8 Ko au total »** : vérifié, la page pèse en réalité 10,3 Ko. Le chiffre est retiré (il redeviendrait faux au prochain changement) ; les affirmations qualitatives durables restent (polices système, mode sombre, pas de lib de mise en page).
- **`softwareVersion`** du JSON-LD : oublié lors du bump vers 1.2.1, corrigé.
- **Table des règles par famille (README)** : pas mise à jour après le déplacement `ECO-CONT-02` → `ECO-UX-06` (PR #10). Comptages et exemples corrigés.
- **Section « En 30 secondes » de la page** : ne montrait que `install.sh`, alors que le README met en avant l'installation par plugin marketplace en premier depuis la PR #7. Les deux surfaces présentent maintenant les méthodes dans le même ordre.

## Vérifié

- Poids réel recalculé après les changements : 10 557 octets / 3 958 octets gzip.
- Total de la table README : 3+5+4+6+2+4+4+3+4 = 35, inchangé.
- Balises HTML équilibrées (`<pre>`/`<p>` comptés avec attributs).