### PR TITLE
Vérifie réellement le poids et les dimensions des images

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,7 @@ Les règles vivent dans `skills/green-claude/rules/ecoconception.json`, organis�
 
 - `patterns` : expressions régulières `grep -E` qui détectent le problème dans le code. Une liste vide fait de la règle une checklist de démarche/gouvernance, ignorée par l'audit automatique — sauf si un `detector` est défini (voir ci-dessous).
 - `detector` (optionnel) : nom d'un détecteur dédié dans `scripts/detect-<nom>.awk`, pour les cas que grep ne peut pas voir car répartis sur plusieurs lignes (ex. `nested_loops` pour les boucles imbriquées). N'utilisez ce mécanisme que si `patterns` ne peut vraiment pas suffire.
+- `enrich` (optionnel) : nom d'un script `scripts/inspect-<nom>.sh`, exécuté en plus de `patterns` (pas à la place) quand la règle a matché, pour ajouter une information réelle qu'un pattern texte ne peut pas donner (ex. `image` pour lire le poids/dimensions réels d'un fichier référencé). Doit rester best-effort : ne rien afficher plutôt que d'affirmer quelque chose de non vérifiable (fichier non résolvable, URL distante).
 - `impact` : `Élevé`, `Moyen` ou `Faible`.
 - `rgesn_ref` renvoie au critère officiel du [RGESN 2024](https://ecoresponsable.numerique.gouv.fr/publications/referentiel-general-ecoconception/) ; utilisez le format `N.x` si la règle relève d'une famille sans correspondre à un critère unique.
 - `gr491_famille` relie la règle au [GR491](https://gr491.isit-europe.org/).

--- a/skills/green-claude/SKILL.md
+++ b/skills/green-claude/SKILL.md
@@ -81,6 +81,12 @@ le contexte avant de le signaler.
 - Un hit ECO-BACK-03 (`nested_loops`) est une boucle imbriquée candidate à O(n²),
   pas une preuve : confirme qu'elle dépend de la taille des données avant de
   recommander un refactor.
+- Un hit ECO-CONT-01 signale la simple mention d'un `.png`/`.jpg` dans le code, pas
+  un défaut de compression ou de dimension : le pattern seul ne peut pas lire le
+  fichier binaire réel. Quand le chemin référencé est résolvable sur disque (pas
+  une URL distante), le rapport ajoute son poids et ses dimensions réels
+  (`scripts/inspect-image.sh`) — vérifie ces chiffres avant de conclure, et ne dis
+  rien de plus que ce que le rapport donne quand le fichier n'est pas résolvable.
 
 ## Ce que ce skill ne fait PAS
 

--- a/skills/green-claude/rules/ecoconception.json
+++ b/skills/green-claude/rules/ecoconception.json
@@ -343,6 +343,8 @@
             "\\.png",
             "\\.jpe?g"
           ],
+          "enrich": "image",
+          "enrich_note": "Un pattern ne peut pas dire si l'image est déjà compressée ou correctement dimensionnée. scripts/inspect-image.sh résout le fichier réel quand c'est possible (pas une URL distante) et ajoute son poids/dimensions réels au rapport, sans rien affirmer quand le fichier n'est pas résolvable.",
           "recommendation": "Convertir en WebP/AVIF, servir des tailles adaptées via srcset, compresser systématiquement.",
           "rgesn_ref": "5.x",
           "gr491_famille": "Contenus",

--- a/skills/green-claude/scripts/eco-audit.sh
+++ b/skills/green-claude/scripts/eco-audit.sh
@@ -49,6 +49,7 @@ while IFS= read -r rule_json; do
     impact=$(jq -r '.impact' <<<"$rule_json")
     patterns=$(jq -r '.patterns | join("|")' <<<"$rule_json")
     detector=$(jq -r '.detector // ""' <<<"$rule_json")
+    enrich=$(jq -r '.enrich // ""' <<<"$rule_json")
     recommendation=$(jq -r '.recommendation' <<<"$rule_json")
     rgesn_ref=$(jq -r '.rgesn_ref' <<<"$rule_json")
 
@@ -69,6 +70,19 @@ while IFS= read -r rule_json; do
             echo "  Fichier        : $file"
             if [ "$matches" != "match" ]; then
                 echo "$matches" | head -5 | sed 's/^/  Ligne          : /'
+            fi
+            if [ -n "$enrich" ]; then
+                # Best-effort : inspecte les fichiers réels référencés (image,
+                # etc.) quand c'est possible. Un pattern seul ne peut pas dire
+                # si une image est déjà compressée ou correctement dimensionnée
+                # — ceci ajoute l'info réelle quand le fichier est résolvable
+                # sur disque, sans rien affirmer quand il ne l'est pas (URL
+                # distante, chemin construit dynamiquement...).
+                enrich_script="$SCRIPT_DIR/inspect-$(echo "$enrich" | tr '_' '-').sh"
+                if [ -f "$enrich_script" ]; then
+                    enrich_out=$(bash "$enrich_script" "$file" 2>/dev/null || true)
+                    [ -n "$enrich_out" ] && echo "$enrich_out" | sed 's/^/  Image          : /'
+                fi
             fi
             echo "  Catégorie      : $category"
             echo "  RGESN          : $rgesn_ref"

--- a/skills/green-claude/scripts/inspect-image.sh
+++ b/skills/green-claude/scripts/inspect-image.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# Enrichissement pour ECO-CONT-01 : un pattern grep sait dire qu'une image
+# .png/.jpg est référencée, pas si elle est déjà compressée ou correctement
+# dimensionnée — ça suppose de lire le fichier binaire réel. Ce script
+# résout les chemins référencés dans le fichier audité et, quand ils
+# existent sur disque, en lit le format/dimensions/poids réels via `file`.
+#
+# Best-effort : une image distante (URL) ou un chemin construit
+# dynamiquement (variable, template) n'est pas résolvable ici — on ne dit
+# rien plutôt que de se tromper. Usage : inspect-image.sh <fichier-audité>
+
+set -euo pipefail
+
+FILE="$1"
+DIR="$(dirname "$FILE")"
+
+command -v file >/dev/null 2>&1 || exit 0
+
+grep -oiE '[^"'"'"'() >]+\.(png|jpe?g)' "$FILE" 2>/dev/null | sort -u | while read -r ref; do
+    # URL distante : rien à inspecter localement.
+    [[ "$ref" =~ ^https?:// ]] && continue
+
+    candidate="$ref"
+    [ -f "$candidate" ] || candidate="$DIR/$ref"
+    [ -f "$candidate" ] || continue
+
+    size_bytes=$(wc -c < "$candidate" 2>/dev/null | tr -d ' ')
+    [ -n "$size_bytes" ] || continue
+    size_ko=$(( (size_bytes + 512) / 1024 ))
+
+    # `file` mentionne parfois une densité DPI avant les vraies dimensions
+    # (ex. JPEG : "density 1x1, ... 1024x529, components 3") : la dernière
+    # occurrence WxH est la bonne, pas la première. Espaces optionnels autour
+    # du x car le format varie selon le type d'image (PNG : "200 x 100").
+    dims=$(file -b "$candidate" 2>/dev/null | grep -oE '[0-9]+ ?x ?[0-9]+' | tail -1 | tr -d ' ')
+
+    if [ -n "$dims" ]; then
+        echo "$ref : ${dims}px, ${size_ko} Ko réels — vérifie que ça correspond à la taille affichée"
+    else
+        echo "$ref : ${size_ko} Ko réels"
+    fi
+done

--- a/skills/green-claude/scripts/test-eco-audit.sh
+++ b/skills/green-claude/scripts/test-eco-audit.sh
@@ -68,4 +68,30 @@ echo "$OUT" | grep -q 'ECO-STRAT-01' || fail "--list-rules omet une règle de d�
 bash eco-audit.sh "$TMP/n-existe-pas.js" >/dev/null 2>&1 \
     || fail "l'audit échoue sur un fichier inexistant au lieu de l'ignorer"
 
-echo "OK - 6 verifications passees"
+# 7. Enrichissement image (ECO-CONT-01) : dimensions/poids réels si le
+# fichier est résolvable sur disque, silence sur une URL distante ou un
+# chemin invalide (rien à affirmer sans pouvoir vérifier).
+python3 -c "
+import struct, zlib
+def chunk(tag, data):
+    return struct.pack('>I', len(data)) + tag + data + struct.pack('>I', zlib.crc32(tag+data))
+sig = b'\x89PNG\r\n\x1a\n'
+ihdr = chunk(b'IHDR', struct.pack('>IIBBBBB', 200, 100, 8, 2, 0, 0, 0))
+raw = b''.join(b'\x00' + b'\xff\x00\x00' * 200 for _ in range(100))
+idat = chunk(b'IDAT', zlib.compress(raw))
+iend = chunk(b'IEND', b'')
+open('$TMP/photo.png','wb').write(sig+ihdr+idat+iend)
+" 2>/dev/null || fail "impossible de générer le PNG de test (python3 requis)"
+
+cat > "$TMP/gallery.html" <<EOF
+<img src="photo.png" alt="reel">
+<img src="https://example.com/remote.png" alt="distant">
+<img src="n-existe-pas.png" alt="invalide">
+EOF
+OUT="$(bash eco-audit.sh "$TMP/gallery.html")"
+echo "$OUT" | grep -q '200x100px' || fail "enrichissement image : dimensions réelles non détectées"
+echo "$OUT" | grep -q 'remote.png' && fail "enrichissement image : ne doit rien affirmer sur une URL distante"
+echo "$OUT" | grep -q 'n-existe-pas.png' && fail "enrichissement image : ne doit rien affirmer sur un fichier absent"
+true
+
+echo "OK - 7 verifications passees"


### PR DESCRIPTION
## Le problème

`ECO-CONT-01` ne fait qu'un grep sur `\.png`/`\.jpe?g` dans le code source : ça détecte qu'une image raster est *référencée*, mais ça ne peut ni dire si elle est déjà compressée ni si ses dimensions sont adaptées à l'affichage — un pattern texte ne lit pas le fichier binaire réel. Un hit ne voulait donc rien dire de plus que « il y a une image ici, à vérifier ».

## La correction

Nouveau mécanisme d'**enrichissement** (champ `enrich` dans les règles, `scripts/inspect-<nom>.sh`) qui s'exécute *en plus* du pattern, pas à sa place :

- `eco-audit.sh` continue de détecter toute mention de `.png`/`.jpg` comme avant (aucune régression sur la couverture existante).
- Quand le chemin référencé est résolvable sur disque (pas une URL distante, pas un chemin construit dynamiquement), `inspect-image.sh` lit le poids et les dimensions réels du fichier via `file` et les ajoute au rapport.
- Reste best-effort : silence total quand le fichier n'est pas résolvable, plutôt que d'affirmer quelque chose de non vérifié.

## Piège rencontré en le faisant

La sortie de `file` sur un JPEG mentionne parfois une densité DPI *avant* les vraies dimensions (`density 1x1, ... 1024x529, components 3`). Prendre la première occurrence `WxH` donne un résultat qui a l'air valide (`1x1`) mais qui est faux — il faut prendre la dernière. Le format varie aussi selon le type d'image (PNG : `200 x 100` avec espaces, JPEG : `1024x529` sans) : la regex accepte les deux. Repéré en testant sur un vrai PNG généré à la volée plutôt qu'en supposant le format de sortie de `file`.

## Documentation

- `SKILL.md` (« Erreurs courantes ») : un hit `ECO-CONT-01` reste un candidat, les chiffres réels ne sont ajoutés que quand le fichier est résolvable.
- `CONTRIBUTING.md` : nouveau champ `enrich` documenté pour les futures règles.

## Testé

`scripts/test-eco-audit.sh` passe à 7/7, nouveau cas ajouté : PNG généré à la volée (dimensions/poids corrects dans le rapport), URL distante et fichier absent (silence confirmé, rien n'est affirmé sans preuve).