### PR TITLE
Vérifie réellement le nombre, le poids et le format des polices

### DIFF
--- a/skills/green-claude/SKILL.md
+++ b/skills/green-claude/SKILL.md
@@ -71,9 +71,11 @@ recommandation de chaque règle. Utile pour une revue de conception en amont du 
 Un hit du script d'audit est un **candidat**, pas une violation confirmée : vérifie
 le contexte avant de le signaler.
 
-- Une `@font-face` auto-hébergée, sous-ensemblée, avec `font-display: swap` suit
-  déjà la recommandation ECO-UX-05 : le pattern matche sans distinguer bon et
-  mauvais usage.
+- ECO-UX-05 (polices) déclenche sur toute mention de police, y compris déjà
+  conforme : si le rapport n'a pas de ligne `Détail`, les polices auto-hébergées
+  résolvables respectent déjà les seuils RGESN 4.8 (2 familles, 4 variantes, 400 Ko,
+  format WOFF2) — inutile de resignaler. Une police tierce (CDN) est toujours
+  signalée sans pouvoir être mesurée : à vérifier manuellement.
 - `deprecated` en commentaire (ECO-ARCH-03) signale souvent une dépréciation
   documentée — une bonne pratique, pas un défaut.
 - ECO-ARCH-01 (react/vue/angular/next) vise le choix initial d'architecture ; ne le

--- a/skills/green-claude/rules/ecoconception.json
+++ b/skills/green-claude/rules/ecoconception.json
@@ -298,13 +298,19 @@
         },
         {
           "id": "ECO-UX-05",
-          "title": "Limiter les polices téléchargées",
-          "description": "Chaque police personnalisée est un téléchargement de plus, bloquant souvent l'affichage du texte.",
+          "title": "Limiter le nombre et le poids des polices téléchargées",
+          "description": "RGESN 4.8 : au maximum 2 polices et 4 variantes au total par page (ou 400 Ko de polices téléchargées au total), avec vérification de la compression. Chaque police est un téléchargement de plus, souvent bloquant pour l'affichage du texte.",
           "impact": "Faible",
           "patterns": [
-            "@font-face"
+            "@font-face",
+            "fonts\\.googleapis\\.com",
+            "fonts\\.gstatic\\.com",
+            "use\\.typekit\\.net",
+            "new FontFace\\("
           ],
-          "recommendation": "Utiliser la pile system-ui ; au maximum deux familles auto-hébergées, sous-ensemblées (subset), avec font-display: swap.",
+          "enrich": "fonts",
+          "enrich_note": "Un pattern ne peut ni compter les polices/variantes ni sommer leur poids réel. scripts/inspect-fonts.sh le fait pour les polices auto-hébergées résolvables sur disque (nombre de familles, variantes, poids total contre 400 Ko, format WOFF2 vs TTF/OTF/EOT) ; les polices tierces (CDN) sont détectées mais leur poids réel n'est pas mesurable sans requête réseau.",
+          "recommendation": "Utiliser la pile system-ui d'abord. Si une police est nécessaire : au maximum 2 familles et 4 variantes au total (ou 400 Ko téléchargés au total), auto-hébergées, sous-ensemblées (subset), en WOFF2, avec font-display: swap.",
           "rgesn_ref": "4.8",
           "gr491_famille": "UX/UI",
           "tags": [

--- a/skills/green-claude/scripts/eco-audit.sh
+++ b/skills/green-claude/scripts/eco-audit.sh
@@ -81,7 +81,7 @@ while IFS= read -r rule_json; do
                 enrich_script="$SCRIPT_DIR/inspect-$(echo "$enrich" | tr '_' '-').sh"
                 if [ -f "$enrich_script" ]; then
                     enrich_out=$(bash "$enrich_script" "$file" 2>/dev/null || true)
-                    [ -n "$enrich_out" ] && echo "$enrich_out" | sed 's/^/  Image          : /'
+                    [ -n "$enrich_out" ] && echo "$enrich_out" | sed 's/^/  Détail         : /'
                 fi
             fi
             echo "  Catégorie      : $category"

--- a/skills/green-claude/scripts/inspect-fonts.sh
+++ b/skills/green-claude/scripts/inspect-fonts.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# Enrichissement pour ECO-UX-05 (polices) — un pattern texte détecte qu'une
+# police est chargée, pas si elle respecte les seuils RGESN 4.8 : au maximum
+# 2 polices et 4 variantes au total (ou 400 Ko de polices téléchargées au
+# total), avec vérification de la compression/du format.
+#
+# Best-effort, comme inspect-image.sh : mesure ce qui est vérifiable
+# localement (police auto-hébergée résolvable sur disque), signale sans
+# mesurer ce qui ne l'est pas (CDN tiers — poids réel inaccessible sans
+# requête réseau).
+#
+# Usage : inspect-fonts.sh <fichier-audité>
+
+set -euo pipefail
+
+FILE="$1"
+DIR="$(dirname "$FILE")"
+SEUIL_EXCES_OCTETS=$((40 * 1024))   # au-delà, police probablement mal optimisée
+SEUIL_TOTAL_OCTETS=$((400 * 1024))  # RGESN 4.8
+
+# --- Polices tierces (CDN) : détectées, mais ni poids ni nombre réels ne
+# sont mesurables sans requête réseau vers le CDN.
+if grep -qiE 'fonts\.googleapis\.com|fonts\.gstatic\.com|use\.typekit\.net' "$FILE" 2>/dev/null; then
+    echo "police(s) tierce(s) détectée(s) (CDN) : poids/nombre réels non mesurables sans requête réseau — vérifie manuellement (RGESN 4.8 : max 2 polices, 4 variantes au total, ou 400 Ko)"
+fi
+
+# --- Polices auto-hébergées : parcourt les blocs @font-face { ... } pour en
+# extraire famille et src, sans dépendre d'un vrai parseur CSS (heuristique
+# ligne à ligne, suffisante pour du CSS formaté normalement).
+families=""
+variants=0
+total_bytes=0
+family=""
+in_block=0
+
+while IFS= read -r line; do
+    if [[ "$line" == *"@font-face"* ]]; then
+        in_block=1
+        family=""
+        continue
+    fi
+    if [ "$in_block" -eq 1 ]; then
+        if [[ "$line" =~ font-family[[:space:]]*:[[:space:]]*[\'\"]?([^\'\";]+) ]]; then
+            family="${BASH_REMATCH[1]}"
+        fi
+        if [[ "$line" =~ url\([\'\"]?([^\'\"\)]+)[\'\"]?\) ]]; then
+            ref="${BASH_REMATCH[1]}"
+            variants=$((variants + 1))
+            [ -n "$family" ] && families="$families
+$family"
+
+            if [[ ! "$ref" =~ ^https?:// ]]; then
+                candidate="$ref"
+                [ -f "$candidate" ] || candidate="$DIR/$ref"
+                if [ -f "$candidate" ]; then
+                    size=$(wc -c < "$candidate" 2>/dev/null | tr -d ' ')
+                    total_bytes=$((total_bytes + size))
+                    excess=$((size - SEUIL_EXCES_OCTETS))
+                    if [ "$excess" -gt 0 ]; then
+                        echo "$(basename "$candidate") : $((size / 1024)) Ko, dépasse le seuil de 40 Ko de $((excess / 1024)) Ko — compression, glyphes surabondants ou formes complexes probablement à revoir"
+                    fi
+                    case "$candidate" in
+                        *.woff2) ;; # déjà le format le plus compressé
+                        *.woff)  echo "$(basename "$candidate") : format WOFF (v1) — WOFF2 compresse mieux" ;;
+                        *.ttf|*.otf) echo "$(basename "$candidate") : format non compressé (TTF/OTF) — préférer WOFF2" ;;
+                        *.eot)   echo "$(basename "$candidate") : format EOT (IE legacy) — obsolète, préférer WOFF2" ;;
+                    esac
+                fi
+            fi
+        fi
+        [[ "$line" == *"}"* ]] && in_block=0
+    fi
+done < "$FILE"
+
+nb_familles=$(printf '%s\n' "$families" | sort -u | grep -c . || true)
+if [ "$nb_familles" -gt 0 ]; then
+    echo "$nb_familles famille(s) auto-hébergée(s) distincte(s), $variants variante(s) au total — seuil RGESN 4.8 : max 2 / 4"
+fi
+if [ "$total_bytes" -gt "$SEUIL_TOTAL_OCTETS" ]; then
+    echo "poids total des polices auto-hébergées résolvables : $((total_bytes / 1024)) Ko — dépasse le seuil RGESN 4.8 de 400 Ko"
+fi

--- a/skills/green-claude/scripts/test-eco-audit.sh
+++ b/skills/green-claude/scripts/test-eco-audit.sh
@@ -94,4 +94,40 @@ echo "$OUT" | grep -q 'remote.png' && fail "enrichissement image : ne doit rien 
 echo "$OUT" | grep -q 'n-existe-pas.png' && fail "enrichissement image : ne doit rien affirmer sur un fichier absent"
 true
 
-echo "OK - 7 verifications passees"
+# 8. ECO-UX-05 (polices) : détection élargie aux CDN tiers, comptage des
+# familles/variantes auto-hébergées et poids réel contre le seuil RGESN 4.8
+# (40 Ko d'excès par police, 400 Ko au total), format non compressé signalé.
+python3 -c "open('$TMP/small.woff2','wb').write(b'\x00' * 20000)"
+python3 -c "open('$TMP/big.woff2','wb').write(b'\x00' * 60000)"
+python3 -c "open('$TMP/legacy.ttf','wb').write(b'\x00' * 15000)"
+
+cat > "$TMP/fonts.css" <<EOF
+@font-face {
+  font-family: "Inter";
+  src: url("small.woff2") format("woff2");
+}
+@font-face {
+  font-family: "Inter";
+  src: url("big.woff2") format("woff2");
+}
+@font-face {
+  font-family: "Legacy";
+  src: url("legacy.ttf") format("truetype");
+}
+EOF
+OUT="$(bash eco-audit.sh "$TMP/fonts.css")"
+echo "$OUT" | grep -q '2 famille(s)' || fail "polices : comptage des familles distinctes incorrect"
+echo "$OUT" | grep -q '3 variante(s)' || fail "polices : comptage des variantes incorrect"
+echo "$OUT" | grep -q 'big.woff2.*40 Ko' || fail "polices : excès au-delà de 40 Ko non détecté"
+echo "$OUT" | grep -q 'legacy.ttf.*non compressé' || fail "polices : format TTF non signalé"
+echo "$OUT" | grep -q 'small.woff2' && fail "polices : ne doit rien signaler sur une police déjà conforme (woff2, < 40 Ko)"
+true
+
+cat > "$TMP/google-fonts.html" <<EOF
+<link href="https://fonts.googleapis.com/css2?family=Roboto" rel="stylesheet">
+EOF
+OUT="$(bash eco-audit.sh "$TMP/google-fonts.html")"
+echo "$OUT" | grep -q 'ECO-UX-05' || fail "polices : Google Fonts (CDN tiers) non détecté du tout"
+echo "$OUT" | grep -q 'non mesurables sans requête réseau' || fail "polices : absence de la mise en garde sur le CDN tiers"
+
+echo "OK - 8 verifications passees"


### PR DESCRIPTION
## Le problème

`ECO-UX-05` ne faisait qu'un grep sur `@font-face` : ça détecte une police auto-hébergée *déclarée par le site*, mais rate le cas le plus courant en pratique — Google Fonts et autres CDN tiers via `<link>`, `@import`, ou l'API `FontFace` en JS. Testé : zéro détection sur les trois. Le seul cas détecté était justement celui déjà conforme à la recommandation (auto-hébergé).

Le critère RGESN 4.8 donne par ailleurs des seuils précis que le pattern ne pouvait pas vérifier : au maximum 2 polices et 4 variantes au total par page (ou 400 Ko de polices téléchargées au total), avec vérification de la compression.

## La correction

- **Patterns élargis** : `fonts.googleapis.com`, `fonts.gstatic.com`, `use.typekit.net`, `new FontFace(`, en plus de `@font-face`.
- **Nouvel enrichissement** (`scripts/inspect-fonts.sh`), pour les polices auto-hébergées résolvables sur disque :
  - compte les familles et variantes distinctes (seuil RGESN : 2 / 4)
  - somme leur poids réel contre le seuil de 400 Ko
  - signale tout fichier individuel dépassant 40 Ko d'excès (métrique distincte du total : une police isolée trop lourde indique souvent un problème de compression ou de glyphes surabondants)
  - signale le format non compressé (TTF/OTF/EOT au lieu de WOFF2)
- **Polices tierces (CDN)** : détectées, mais rien de mesurable sans requête réseau — signalées comme telles, à vérifier manuellement, sans chiffre inventé.

## Bug trouvé en testant

La sortie de l'enrichissement image et celle des polices utilisaient le même libellé `Image` dans `eco-audit.sh` — copié-collé non adapté du travail précédent sur `ECO-CONT-01`. Renommé en `Détail`, générique pour tout mécanisme `enrich` actuel ou futur.

## Testé

- 2 familles / 3 variantes comptées correctement sur un cas réaliste
- Police à 58 Ko signalée (excès de 18 Ko au-delà du seuil de 40)
- Format TTF signalé, format WOFF2 conforme silencieux
- Police déjà conforme (WOFF2, < 40 Ko) : aucune ligne `Détail` — silence correct
- Google Fonts détecté et correctement signalé comme non mesurable localement

`scripts/test-eco-audit.sh` passe à 8/8.