### PR TITLE
Ajoute une règle sur la qualité du code (testé, robuste, maintenable)

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ L'audit (`skills/green-claude/scripts/eco-audit.sh`) est un script déterministe
 
 ---
 
-## Les règles : 35 règles alignées sur les 9 familles du RGESN 2024
+## Les règles : 36 règles alignées sur les 9 familles du RGESN 2024
 
 [`skills/green-claude/rules/ecoconception.json`](skills/green-claude/rules/ecoconception.json) couvre les **9 familles** du [RGESN 2024](https://www.arcep.fr/mes-demarches-et-services/entreprises/fiches-pratiques/referentiel-general-ecoconception-services-numeriques.html) (78 critères officiels). Chaque règle référence le critère RGESN correspondant (`rgesn_ref`) et la famille [GR491](https://gr491.isit-europe.org/) (`gr491_famille`) :
 
@@ -82,7 +82,7 @@ L'audit (`skills/green-claude/scripts/eco-audit.sh`) est un script déterministe
 |---|---|---|
 | 1. Stratégie | 3 | Mesurer avant d'optimiser, données raisonnées, formats ouverts |
 | 2. Spécifications | 5 | Compatibilité anciens terminaux, bas débit, impact des services tiers |
-| 3. Architecture | 4 | Low-tech d'abord, ressources adaptées à la charge, environnements de test sobres |
+| 3. Architecture | 5 | Low-tech d'abord, ressources adaptées à la charge, environnements de test sobres, code testé et maintenable |
 | 4. UX/UI | 6 | Pas d'autoplay ni de scroll infini, composants natifs, polices limitées, média le plus sobre |
 | 5. Contenus | 2 | Images optimisées, SVG |
 | 6. Frontend | 4 | Pas de bibliothèque lourde, lazy loading, minification, dépendances |

--- a/docs/index.html
+++ b/docs/index.html
@@ -121,7 +121,7 @@
   <div class="duo">
     <div class="card">
       <h3>Pendant que Claude code</h3>
-      <p>35 règles d'éco-conception alignées sur les 9 familles du RGESN 2024, avec renvoi aux critères officiels : Claude les applique de lui-même en écrivant du code, sans qu'on le lui demande à chaque fois.</p>
+      <p>36 règles d'éco-conception alignées sur les 9 familles du RGESN 2024, avec renvoi aux critères officiels : Claude les applique de lui-même en écrivant du code, sans qu'on le lui demande à chaque fois.</p>
     </div>
     <div class="card">
       <h3>Sur demande, un audit</h3>
@@ -140,7 +140,7 @@ cd green-claude && ./install.sh</code></pre>
   <h2>Ce que contient le projet</h2>
   <ul>
     <li>Un skill Claude Code qui s'invoque tout seul dès qu'il s'agit d'écrire ou de revoir du code.</li>
-    <li>35 règles d'éco-conception couvrant les 9 familles du <a href="https://ecoresponsable.numerique.gouv.fr/publications/referentiel-general-ecoconception/">RGESN 2024</a>, dont l'Algorithmie et l'IA frugale, reliées au <a href="https://gr491.isit-europe.org/">GR491</a>.</li>
+    <li>36 règles d'éco-conception couvrant les 9 familles du <a href="https://ecoresponsable.numerique.gouv.fr/publications/referentiel-general-ecoconception/">RGESN 2024</a>, dont l'Algorithmie et l'IA frugale, reliées au <a href="https://gr491.isit-europe.org/">GR491</a>.</li>
     <li>14 pratiques de sobriété inspirées de Boris Cherny, le créateur de Claude Code : chacune est sourcée et expliquée.</li>
     <li>Un hook optionnel pour le cache local des réponses et un avertissement aux heures de pointe, proposé à l'installation, jamais imposé.</li>
   </ul>

--- a/skills/green-claude/SKILL.md
+++ b/skills/green-claude/SKILL.md
@@ -15,7 +15,7 @@ user-invocable: true
 
 # Green Claude
 
-Deux jeux de règles : `rules/ecoconception.json` (35 règles, RGESN 2024 / GR491 /
+Deux jeux de règles : `rules/ecoconception.json` (36 règles, RGESN 2024 / GR491 /
 Green Software Foundation) pendant que tu écris ou modifies du code, et
 `rules/boris.json` (14 pratiques d'usage) pendant la conversation elle-même. Un
 usage efficace de Claude Code est aussi un usage sobre.

--- a/skills/green-claude/rules/ecoconception.json
+++ b/skills/green-claude/rules/ecoconception.json
@@ -1,15 +1,15 @@
 {
   "metadata": {
     "name": "Éco-conception de services numériques — RGESN 2024 / GR491 / GSF",
-    "description": "35 règles d'éco-conception couvrant les 9 familles du RGESN 2024 (Référentiel Général d'Écoconception de Services Numériques, 78 critères). Chaque règle référence le ou les critères RGESN correspondants (champ rgesn_ref) et la famille GR491 (champ gr491_famille).",
+    "description": "36 règles d'éco-conception couvrant les 9 familles du RGESN 2024 (Référentiel Général d'Écoconception de Services Numériques, 78 critères). Chaque règle référence le ou les critères RGESN correspondants (champ rgesn_ref) et la famille GR491 (champ gr491_famille).",
     "version": "3.0.0",
     "sources": [
       "https://ecoresponsable.numerique.gouv.fr/publications/referentiel-general-ecoconception/",
       "https://gr491.isit-europe.org/",
       "https://greensoftware.foundation/"
     ],
-    "coverage_note": "Le RGESN 2024 compte 78 critères en 9 familles ; le GR491 compte 61 recommandations et 516 critères en 8 familles. Ce fichier sélectionne 35 règles actionnables sans reproduire le référentiel complet : chaque famille RGESN est représentée, et le champ rgesn_ref renvoie au critère officiel pour approfondir. rgesn_ref au format 'N.x' signifie que la règle relève de la famille N sans correspondre à un critère unique.",
-    "count": 35,
+    "coverage_note": "Le RGESN 2024 compte 78 critères en 9 familles ; le GR491 compte 61 recommandations et 516 critères en 8 familles. Ce fichier sélectionne 36 règles actionnables sans reproduire le référentiel complet : chaque famille RGESN est représentée, et le champ rgesn_ref renvoie au critère officiel pour approfondir. rgesn_ref au format 'N.x' signifie que la règle relève de la famille N sans correspondre à un critère unique.",
+    "count": 36,
     "type": "code_audit",
     "type_note": "Les règles avec 'patterns' sont détectées dans le code par l'audit (grep). Les règles avec 'detector' utilisent un détecteur dédié multi-lignes (scripts/detect-*.awk) quand grep ligne-par-ligne ne suffit pas. Celles sans pattern ni detector sont des règles de conception/processus : elles servent de checklist via --list-rules."
   },
@@ -220,6 +220,23 @@
             "ci-cd",
             "environnements",
             "mutualisation"
+          ]
+        },
+        {
+          "id": "ECO-ARCH-05",
+          "title": "Écrire du code de qualité : testé, robuste, performant et maintenable",
+          "description": "Un code mal testé, fragile ou mal structuré génère plus de correctifs, de redéploiements et de recalculs après coup — chaque bug corrigé une fois le service en production coûte plus de ressources que d'écrire juste du premier coup.",
+          "impact": "Moyen",
+          "patterns": [],
+          "recommendation": "Teste le code avant de le livrer, gère les erreurs et les cas limites, mesure la performance des chemins critiques, garde une structure simple pour qu'elle reste maintenable sans réécriture complète.",
+          "rgesn_ref": "GSF",
+          "gr491_famille": "Architecture",
+          "source_note": "Principe proposé par Guillaume G. (Institut du Numérique Responsable), à partir de la thèse générale de la Green Software Foundation reliant qualité du code et sobriété numérique (greensoftware.foundation/articles/green-coding-is-a-matter-of-code-quality) : pas un critère RGESN numéroté, d'où rgesn_ref = \"GSF\" plutôt qu'un format N.x.",
+          "tags": [
+            "qualite",
+            "tests",
+            "maintenabilite",
+            "robustesse"
           ]
         }
       ]


### PR DESCRIPTION
## Le principe

Proposé par Guillaume G. (Institut du Numérique Responsable) : un code mal testé, fragile ou mal structuré génère plus de correctifs, de redéploiements et de recalculs après coup — chaque bug corrigé une fois le service en production coûte plus de ressources que d'écrire juste du premier coup.

## Sourcing

Vérifié avant d'ajouter : aucune des 35 règles existantes ni des 78 critères RGESN ne couvrait cet angle (CONTRIBUTING.md interdit les règles maison sans source). La thèse générale reliant qualité du code et sobriété numérique est documentée par la Green Software Foundation ([greensoftware.foundation/articles/green-coding-is-a-matter-of-code-quality](https://greensoftware.foundation/articles/green-coding-is-a-matter-of-code-quality/)), déjà une des trois sources du projet.

Ce n'est pas un critère RGESN numéroté : `rgesn_ref = "GSF"` plutôt qu'un format `N.x`, pour rester honnête sur cette origine, avec un champ `source_note` qui explicite l'attribution à Guillaume G.

## Placement

`ECO-ARCH-05`, famille Architecture — aux côtés d'`ECO-ARCH-03` ("concevoir pour durer"), philosophiquement proche. Règle de démarche sans pattern détectable, comme la plupart des règles de cette famille.

## Mis à jour en conséquence

36 règles au total désormais (était 35) : `ecoconception.json` (description, coverage_note, count), `README.md` (titre de section, table par famille — Architecture passe de 4 à 5), `docs/index.html` (les deux mentions du total).

## Vérifié

- `jq empty` : passe
- `claude plugin validate` : passe
- `scripts/test-eco-audit.sh` : 8/8
- La nouvelle règle apparaît correctement dans `--list-rules`
- Total de la table README recalculé : 36