### PR TITLE
Détecte le code mort après return/throw (ECO-FRONT-05)

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ L'audit (`skills/green-claude/scripts/eco-audit.sh`) est un script déterministe
 
 ---
 
-## Les règles : 36 règles alignées sur les 9 familles du RGESN 2024
+## Les règles : 37 règles alignées sur les 9 familles du RGESN 2024
 
 [`skills/green-claude/rules/ecoconception.json`](skills/green-claude/rules/ecoconception.json) couvre les **9 familles** du [RGESN 2024](https://www.arcep.fr/mes-demarches-et-services/entreprises/fiches-pratiques/referentiel-general-ecoconception-services-numeriques.html) (78 critères officiels). Chaque règle référence le critère RGESN correspondant (`rgesn_ref`) et la famille [GR491](https://gr491.isit-europe.org/) (`gr491_famille`) :
 
@@ -85,7 +85,7 @@ L'audit (`skills/green-claude/scripts/eco-audit.sh`) est un script déterministe
 | 3. Architecture | 5 | Low-tech d'abord, ressources adaptées à la charge, environnements de test sobres, code testé et maintenable |
 | 4. UX/UI | 6 | Pas d'autoplay ni de scroll infini, composants natifs, polices limitées, média le plus sobre |
 | 5. Contenus | 2 | Images optimisées, SVG |
-| 6. Frontend | 4 | Pas de bibliothèque lourde, lazy loading, minification, dépendances |
+| 6. Frontend | 5 | Pas de bibliothèque lourde, lazy loading, minification, dépendances, pas de code mort |
 | 7. Backend | 4 | SQL optimisé, pools de connexions, complexité, pagination + cache |
 | 8. Hébergement | 3 | Hébergeur sobre, compression HTTP, cache HTTP |
 | 9. **Algorithmie (dont IA)** | 4 | **Justifier l'IA, dimensionner le modèle, mesurer, alternatives sobres** |

--- a/docs/index.html
+++ b/docs/index.html
@@ -121,7 +121,7 @@
   <div class="duo">
     <div class="card">
       <h3>Pendant que Claude code</h3>
-      <p>36 règles d'éco-conception alignées sur les 9 familles du RGESN 2024, avec renvoi aux critères officiels : Claude les applique de lui-même en écrivant du code, sans qu'on le lui demande à chaque fois.</p>
+      <p>37 règles d'éco-conception alignées sur les 9 familles du RGESN 2024, avec renvoi aux critères officiels : Claude les applique de lui-même en écrivant du code, sans qu'on le lui demande à chaque fois.</p>
     </div>
     <div class="card">
       <h3>Sur demande, un audit</h3>
@@ -140,7 +140,7 @@ cd green-claude && ./install.sh</code></pre>
   <h2>Ce que contient le projet</h2>
   <ul>
     <li>Un skill Claude Code qui s'invoque tout seul dès qu'il s'agit d'écrire ou de revoir du code.</li>
-    <li>36 règles d'éco-conception couvrant les 9 familles du <a href="https://ecoresponsable.numerique.gouv.fr/publications/referentiel-general-ecoconception/">RGESN 2024</a>, dont l'Algorithmie et l'IA frugale, reliées au <a href="https://gr491.isit-europe.org/">GR491</a>.</li>
+    <li>37 règles d'éco-conception couvrant les 9 familles du <a href="https://ecoresponsable.numerique.gouv.fr/publications/referentiel-general-ecoconception/">RGESN 2024</a>, dont l'Algorithmie et l'IA frugale, reliées au <a href="https://gr491.isit-europe.org/">GR491</a>.</li>
     <li>14 pratiques de sobriété inspirées de Boris Cherny, le créateur de Claude Code : chacune est sourcée et expliquée.</li>
     <li>Un hook optionnel pour le cache local des réponses et un avertissement aux heures de pointe, proposé à l'installation, jamais imposé.</li>
   </ul>

--- a/skills/green-claude/SKILL.md
+++ b/skills/green-claude/SKILL.md
@@ -15,7 +15,7 @@ user-invocable: true
 
 # Green Claude
 
-Deux jeux de règles : `rules/ecoconception.json` (36 règles, RGESN 2024 / GR491 /
+Deux jeux de règles : `rules/ecoconception.json` (37 règles, RGESN 2024 / GR491 /
 Green Software Foundation) pendant que tu écris ou modifies du code, et
 `rules/boris.json` (14 pratiques d'usage) pendant la conversation elle-même. Un
 usage efficace de Claude Code est aussi un usage sobre.
@@ -83,6 +83,10 @@ le contexte avant de le signaler.
 - Un hit ECO-BACK-03 (`nested_loops`) est une boucle imbriquée candidate à O(n²),
   pas une preuve : confirme qu'elle dépend de la taille des données avant de
   recommander un refactor.
+- Un hit ECO-FRONT-05 (`dead_code`) signale du code après un
+  return/throw/break/continue non conditionnel dans le même bloc — pas un code
+  mort à l'exécution runtime en général (un bloc jamais atteint par ailleurs
+  n'est pas détectable statiquement).
 - Un hit ECO-CONT-01 signale la simple mention d'un `.png`/`.jpg` dans le code, pas
   un défaut de compression ou de dimension : le pattern seul ne peut pas lire le
   fichier binaire réel. Quand le chemin référencé est résolvable sur disque (pas

--- a/skills/green-claude/rules/ecoconception.json
+++ b/skills/green-claude/rules/ecoconception.json
@@ -1,15 +1,15 @@
 {
   "metadata": {
     "name": "Éco-conception de services numériques — RGESN 2024 / GR491 / GSF",
-    "description": "36 règles d'éco-conception couvrant les 9 familles du RGESN 2024 (Référentiel Général d'Écoconception de Services Numériques, 78 critères). Chaque règle référence le ou les critères RGESN correspondants (champ rgesn_ref) et la famille GR491 (champ gr491_famille).",
+    "description": "37 règles d'éco-conception couvrant les 9 familles du RGESN 2024 (Référentiel Général d'Écoconception de Services Numériques, 78 critères). Chaque règle référence le ou les critères RGESN correspondants (champ rgesn_ref) et la famille GR491 (champ gr491_famille).",
     "version": "3.0.0",
     "sources": [
       "https://ecoresponsable.numerique.gouv.fr/publications/referentiel-general-ecoconception/",
       "https://gr491.isit-europe.org/",
       "https://greensoftware.foundation/"
     ],
-    "coverage_note": "Le RGESN 2024 compte 78 critères en 9 familles ; le GR491 compte 61 recommandations et 516 critères en 8 familles. Ce fichier sélectionne 36 règles actionnables sans reproduire le référentiel complet : chaque famille RGESN est représentée, et le champ rgesn_ref renvoie au critère officiel pour approfondir. rgesn_ref au format 'N.x' signifie que la règle relève de la famille N sans correspondre à un critère unique.",
-    "count": 36,
+    "coverage_note": "Le RGESN 2024 compte 78 critères en 9 familles ; le GR491 compte 61 recommandations et 516 critères en 8 familles. Ce fichier sélectionne 37 règles actionnables sans reproduire le référentiel complet : chaque famille RGESN est représentée, et le champ rgesn_ref renvoie au critère officiel pour approfondir. rgesn_ref au format 'N.x' signifie que la règle relève de la famille N sans correspondre à un critère unique.",
+    "count": 37,
     "type": "code_audit",
     "type_note": "Les règles avec 'patterns' sont détectées dans le code par l'audit (grep). Les règles avec 'detector' utilisent un détecteur dédié multi-lignes (scripts/detect-*.awk) quand grep ligne-par-ligne ne suffit pas. Celles sans pattern ni detector sont des règles de conception/processus : elles servent de checklist via --list-rules."
   },
@@ -462,6 +462,23 @@
           "tags": [
             "dependances",
             "minimalisme",
+            "maintenance"
+          ]
+        },
+        {
+          "id": "ECO-FRONT-05",
+          "title": "Pas de code mort",
+          "description": "Du code inatteignable (après un return/throw non conditionnel) est quand même téléchargé et parsé par chaque visiteur, pour un bénéfice nul.",
+          "impact": "Faible",
+          "patterns": [],
+          "detector": "dead_code",
+          "detector_note": "Un grep ligne-par-ligne ne peut pas suivre les blocs : scripts/detect-dead-code.awk suit la profondeur des accolades pour ne signaler que le code inatteignable dans le MÊME bloc qu'un return/throw/break/continue, en ignorant les limites de case/default et les blocs qui referment le bloc surveillé sur la même ligne (\"} catch {\", \"} else {\").",
+          "recommendation": "Supprimer le code mort repéré ; s'il s'agit d'un early-return de débogage temporaire, le retirer avant de livrer.",
+          "rgesn_ref": "6.x",
+          "gr491_famille": "Front-end",
+          "tags": [
+            "code-mort",
+            "javascript",
             "maintenance"
           ]
         }

--- a/skills/green-claude/scripts/detect-dead-code.awk
+++ b/skills/green-claude/scripts/detect-dead-code.awk
@@ -1,0 +1,66 @@
+# Détecteur de code mort JS/TS (ECO-FRONT-05) : instructions inatteignables
+# après un return/throw/break/continue, dans le même bloc. Suit la
+# profondeur des accolades pour savoir quand ce bloc se referme (le code
+# mort ne l'est que jusqu'à la fin de SON bloc, pas au-delà) et reconnaît les
+# limites de case/default (le fallthrough syntaxique d'un switch n'est pas
+# du code mort).
+#
+# Piège géré explicitement : la fermeture du bloc surveillé peut partager sa
+# ligne avec la suite du code ("} catch (e) {", "} else {" — un style très
+# courant). Le scan caractère par caractère repère le point exact où la
+# profondeur retombe sous le seuil surveillé ; tout ce qui suit ce point,
+# même sur la même ligne, n'est plus considéré comme mort.
+#
+# Sortie : "numéro_de_ligne:ligne" pour la première ligne inatteignable de
+# chaque zone morte. Heuristique assumée : un détecteur de CANDIDATS, pas
+# une preuve (un return dans un bloc jamais exécuté à l'exécution, un code
+# de débogage volontairement laissé après un early-return temporaire...).
+
+BEGIN { depth = 0; dead_depth = -1; flagged_this_zone = 0 }
+
+{
+    line = $0
+    trimmed = line
+    gsub(/^[ \t]+/, "", trimmed)
+    gsub(/[ \t]+$/, "", trimmed)
+
+    # Une seule passe caractère par caractère : met à jour la profondeur
+    # réelle et repère au passage, si une zone morte est surveillée, le
+    # premier point où elle se referme sur cette ligne.
+    close_pos = 0
+    n = length(line)
+    for (i = 1; i <= n; i++) {
+        c = substr(line, i, 1)
+        if (c == "{") {
+            depth++
+        } else if (c == "}") {
+            depth--
+            if (dead_depth >= 0 && depth < dead_depth && close_pos == 0) close_pos = i
+        }
+    }
+
+    if (dead_depth >= 0) {
+        if (close_pos > 0) {
+            before = substr(line, 1, close_pos - 1)
+            gsub(/^[ \t]+/, "", before); gsub(/[ \t]+$/, "", before)
+            if (before != "" && !flagged_this_zone) {
+                printf "%d:%s\n", NR, line
+                flagged_this_zone = 1
+            }
+            dead_depth = -1  # bloc refermé : fin de la zone surveillée
+        } else if (trimmed ~ /^(case[ \t(]|default[ \t]*:)/) {
+            dead_depth = -1  # nouveau case : pas mort, juste une autre entrée
+        } else if (trimmed !~ /^(\/\/|\*|\/\*)/ && trimmed != "" && !flagged_this_zone) {
+            printf "%d:%s\n", NR, line
+            flagged_this_zone = 1  # une seule ligne signalée par zone morte
+        }
+    }
+
+    # Un return/throw/break/continue (mot entier, pour ne pas matcher un
+    # identifiant du genre "returnValue") ouvre une nouvelle zone surveillée,
+    # à la profondeur constatée après cette ligne.
+    if (dead_depth < 0 && trimmed ~ /(^|[^[:alnum:]_.])(return|throw|break|continue)([ \t;()]|$)/) {
+        dead_depth = depth
+        flagged_this_zone = 0
+    }
+}

--- a/skills/green-claude/scripts/test-eco-audit.sh
+++ b/skills/green-claude/scripts/test-eco-audit.sh
@@ -130,4 +130,42 @@ OUT="$(bash eco-audit.sh "$TMP/google-fonts.html")"
 echo "$OUT" | grep -q 'ECO-UX-05' || fail "polices : Google Fonts (CDN tiers) non détecté du tout"
 echo "$OUT" | grep -q 'non mesurables sans requête réseau' || fail "polices : absence de la mise en garde sur le CDN tiers"
 
-echo "OK - 8 verifications passees"
+# 9. ECO-FRONT-05 (code mort) : détecte le vrai code inatteignable après un
+# return/throw, sans se faire piéger par les cas très courants où le bloc
+# surveillé se referme sur la même ligne que la suite du code (try/catch,
+# if/else) ni par le fallthrough syntaxique d'un switch/case.
+cat > "$TMP/dead.js" <<'EOF'
+function foo() {
+  return 42;
+  console.log("mort");
+}
+function bar(x) {
+  if (x) {
+    return 1;
+  }
+  console.log("atteignable, hors du if");
+}
+function classify(x) {
+  switch (x) {
+    case 1:
+      return "un";
+    default:
+      return "autre";
+  }
+}
+function safe() {
+  try {
+    return risky();
+  } catch (e) {
+    console.log("gestion erreur, atteignable");
+  }
+}
+EOF
+OUT="$(bash eco-audit.sh "$TMP/dead.js")"
+echo "$OUT" | grep -q 'mort");' || fail "code mort : vrai positif (après return) non détecté"
+echo "$OUT" | grep -q 'hors du if' && fail "code mort : faux positif (code après un if contenant un return)"
+echo "$OUT" | grep -q 'gestion erreur' && fail "code mort : faux positif (catch après un return dans le try)"
+N=$(echo "$OUT" | grep -c 'ECO-FRONT-05')
+[ "$N" -eq 1 ] || fail "code mort : attendu 1 seul hit sur ce fichier, trouvé $N"
+
+echo "OK - 9 verifications passees"


### PR DESCRIPTION
## Contexte

Suite à l'audit demandé sur la qualité JS/CSS du projet : ESLint et stylelint tournés sur le JS/CSS de `docs/index.html` ne trouvent rien de réel (1 seul finding ESLint — une globale volontaire imposée par le snippet Matomo standard, pas un bug). Mais rien dans les règles `ecoconception.json` ne couvrait le code mort comme angle d'éco-conception pour le code que Claude écrit ailleurs : du code inatteignable est quand même téléchargé et parsé par chaque visiteur, pour un bénéfice nul.

## La règle

Nouveau détecteur dédié (`scripts/detect-dead-code.awk`), même famille technique que `detect-nested-loops.awk` (suivi de la profondeur des accolades — un grep ligne-par-ligne ne peut pas voir un bloc). Signale la première ligne inatteignable après un `return`/`throw`/`break`/`continue` non conditionnel, dans le même bloc.

## Bug trouvé et corrigé en testant

Le cas le plus courant en JS réel est qu'un bloc se referme sur la même ligne que la suite du code (`} catch (e) {`, `} else {`). La première version du détecteur comparait la profondeur *avant* de compter les accolades de la ligne elle-même, et signalait donc à tort le contenu du catch/else comme mort — alors qu'il est parfaitement atteignable. Corrigé en scannant caractère par caractère : le point exact où la profondeur repasse sous le seuil surveillé met fin à la zone morte, même au milieu d'une ligne partagée avec du code qui suit.

Les limites de `case`/`default` (fallthrough syntaxique d'un switch) sont aussi explicitement exclues : chaque case a son propre point d'entrée, un `return` dans le case précédent n'y rend rien mort.

## Testé

4 cas positifs/négatifs distincts en plus du cas piège try/catch, intégrés à `scripts/test-eco-audit.sh` (passe à 9/9) :
- `return` suivi de code réel → détecté
- `return` dans un `if`, code après le `if` (hors du bloc) → silencieux
- `switch`/`case`, chaque case a son `return` → silencieux
- `try`/`catch`, `catch` atteignable → silencieux (le bug corrigé)

## Mis à jour en conséquence

37 règles au total désormais (était 36), `ECO-FRONT-05` dans la famille Frontend aux côtés d'`ECO-FRONT-04` (nettoyage des dépendances, préoccupation voisine). Comptages mis à jour dans `README.md`, `docs/index.html` et `ecoconception.json`.