### PR TITLE
Détecte les variables globales implicites (ECO-FRONT-06)

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ L'audit (`skills/green-claude/scripts/eco-audit.sh`) est un script déterministe
 
 ---
 
-## Les règles : 37 règles alignées sur les 9 familles du RGESN 2024
+## Les règles : 38 règles alignées sur les 9 familles du RGESN 2024
 
 [`skills/green-claude/rules/ecoconception.json`](skills/green-claude/rules/ecoconception.json) couvre les **9 familles** du [RGESN 2024](https://www.arcep.fr/mes-demarches-et-services/entreprises/fiches-pratiques/referentiel-general-ecoconception-services-numeriques.html) (78 critères officiels). Chaque règle référence le critère RGESN correspondant (`rgesn_ref`) et la famille [GR491](https://gr491.isit-europe.org/) (`gr491_famille`) :
 
@@ -85,7 +85,7 @@ L'audit (`skills/green-claude/scripts/eco-audit.sh`) est un script déterministe
 | 3. Architecture | 5 | Low-tech d'abord, ressources adaptées à la charge, environnements de test sobres, code testé et maintenable |
 | 4. UX/UI | 6 | Pas d'autoplay ni de scroll infini, composants natifs, polices limitées, média le plus sobre |
 | 5. Contenus | 2 | Images optimisées, SVG |
-| 6. Frontend | 5 | Pas de bibliothèque lourde, lazy loading, minification, dépendances, pas de code mort |
+| 6. Frontend | 6 | Pas de bibliothèque lourde, lazy loading, minification, dépendances, pas de code mort, pas de globales implicites |
 | 7. Backend | 4 | SQL optimisé, pools de connexions, complexité, pagination + cache |
 | 8. Hébergement | 3 | Hébergeur sobre, compression HTTP, cache HTTP |
 | 9. **Algorithmie (dont IA)** | 4 | **Justifier l'IA, dimensionner le modèle, mesurer, alternatives sobres** |

--- a/docs/index.html
+++ b/docs/index.html
@@ -121,7 +121,7 @@
   <div class="duo">
     <div class="card">
       <h3>Pendant que Claude code</h3>
-      <p>37 règles d'éco-conception alignées sur les 9 familles du RGESN 2024, avec renvoi aux critères officiels : Claude les applique de lui-même en écrivant du code, sans qu'on le lui demande à chaque fois.</p>
+      <p>38 règles d'éco-conception alignées sur les 9 familles du RGESN 2024, avec renvoi aux critères officiels : Claude les applique de lui-même en écrivant du code, sans qu'on le lui demande à chaque fois.</p>
     </div>
     <div class="card">
       <h3>Sur demande, un audit</h3>
@@ -140,7 +140,7 @@ cd green-claude && ./install.sh</code></pre>
   <h2>Ce que contient le projet</h2>
   <ul>
     <li>Un skill Claude Code qui s'invoque tout seul dès qu'il s'agit d'écrire ou de revoir du code.</li>
-    <li>37 règles d'éco-conception couvrant les 9 familles du <a href="https://ecoresponsable.numerique.gouv.fr/publications/referentiel-general-ecoconception/">RGESN 2024</a>, dont l'Algorithmie et l'IA frugale, reliées au <a href="https://gr491.isit-europe.org/">GR491</a>.</li>
+    <li>38 règles d'éco-conception couvrant les 9 familles du <a href="https://ecoresponsable.numerique.gouv.fr/publications/referentiel-general-ecoconception/">RGESN 2024</a>, dont l'Algorithmie et l'IA frugale, reliées au <a href="https://gr491.isit-europe.org/">GR491</a>.</li>
     <li>14 pratiques de sobriété inspirées de Boris Cherny, le créateur de Claude Code : chacune est sourcée et expliquée.</li>
     <li>Un hook optionnel pour le cache local des réponses et un avertissement aux heures de pointe, proposé à l'installation, jamais imposé.</li>
   </ul>

--- a/skills/green-claude/SKILL.md
+++ b/skills/green-claude/SKILL.md
@@ -15,7 +15,7 @@ user-invocable: true
 
 # Green Claude
 
-Deux jeux de règles : `rules/ecoconception.json` (37 règles, RGESN 2024 / GR491 /
+Deux jeux de règles : `rules/ecoconception.json` (38 règles, RGESN 2024 / GR491 /
 Green Software Foundation) pendant que tu écris ou modifies du code, et
 `rules/boris.json` (14 pratiques d'usage) pendant la conversation elle-même. Un
 usage efficace de Claude Code est aussi un usage sobre.
@@ -87,6 +87,10 @@ le contexte avant de le signaler.
   return/throw/break/continue non conditionnel dans le même bloc — pas un code
   mort à l'exécution runtime en général (un bloc jamais atteint par ailleurs
   n'est pas détectable statiquement).
+- Un hit ECO-FRONT-06 (`implicit_globals`) signale une déclaration/affectation
+  au niveau racine d'un script — un candidat à vérifier, pas forcément une
+  erreur : une globale imposée par un script tiers (Matomo, etc.) en est un
+  exemple légitime, à confirmer plutôt qu'à corriger d'office.
 - Un hit ECO-CONT-01 signale la simple mention d'un `.png`/`.jpg` dans le code, pas
   un défaut de compression ou de dimension : le pattern seul ne peut pas lire le
   fichier binaire réel. Quand le chemin référencé est résolvable sur disque (pas

--- a/skills/green-claude/rules/ecoconception.json
+++ b/skills/green-claude/rules/ecoconception.json
@@ -1,15 +1,15 @@
 {
   "metadata": {
     "name": "Éco-conception de services numériques — RGESN 2024 / GR491 / GSF",
-    "description": "37 règles d'éco-conception couvrant les 9 familles du RGESN 2024 (Référentiel Général d'Écoconception de Services Numériques, 78 critères). Chaque règle référence le ou les critères RGESN correspondants (champ rgesn_ref) et la famille GR491 (champ gr491_famille).",
+    "description": "38 règles d'éco-conception couvrant les 9 familles du RGESN 2024 (Référentiel Général d'Écoconception de Services Numériques, 78 critères). Chaque règle référence le ou les critères RGESN correspondants (champ rgesn_ref) et la famille GR491 (champ gr491_famille).",
     "version": "3.0.0",
     "sources": [
       "https://ecoresponsable.numerique.gouv.fr/publications/referentiel-general-ecoconception/",
       "https://gr491.isit-europe.org/",
       "https://greensoftware.foundation/"
     ],
-    "coverage_note": "Le RGESN 2024 compte 78 critères en 9 familles ; le GR491 compte 61 recommandations et 516 critères en 8 familles. Ce fichier sélectionne 37 règles actionnables sans reproduire le référentiel complet : chaque famille RGESN est représentée, et le champ rgesn_ref renvoie au critère officiel pour approfondir. rgesn_ref au format 'N.x' signifie que la règle relève de la famille N sans correspondre à un critère unique.",
-    "count": 37,
+    "coverage_note": "Le RGESN 2024 compte 78 critères en 9 familles ; le GR491 compte 61 recommandations et 516 critères en 8 familles. Ce fichier sélectionne 38 règles actionnables sans reproduire le référentiel complet : chaque famille RGESN est représentée, et le champ rgesn_ref renvoie au critère officiel pour approfondir. rgesn_ref au format 'N.x' signifie que la règle relève de la famille N sans correspondre à un critère unique.",
+    "count": 38,
     "type": "code_audit",
     "type_note": "Les règles avec 'patterns' sont détectées dans le code par l'audit (grep). Les règles avec 'detector' utilisent un détecteur dédié multi-lignes (scripts/detect-*.awk) quand grep ligne-par-ligne ne suffit pas. Celles sans pattern ni detector sont des règles de conception/processus : elles servent de checklist via --list-rules."
   },
@@ -479,6 +479,23 @@
           "tags": [
             "code-mort",
             "javascript",
+            "maintenance"
+          ]
+        },
+        {
+          "id": "ECO-FRONT-06",
+          "title": "Éviter les variables globales implicites",
+          "description": "Une variable déclarée (ou affectée sans mot-clé) au premier niveau d'un script classique reste en vie pour toute la durée de la page et est visible de tout autre script — retenue en mémoire plus longtemps que nécessaire, avec un risque de collision.",
+          "impact": "Faible",
+          "patterns": [],
+          "detector": "implicit_globals",
+          "detector_note": "scripts/detect-implicit-globals.awk signale toute déclaration var/let/const ou affectation nue au niveau racine (profondeur d'accolades 0) d'un fichier ; rien à l'intérieur d'une fonction ou d'une IIFE. Limite assumée : un <script type=\"module\"> n'a pas cette sémantique de portée globale au premier niveau, mais le détecteur ne reçoit que le contenu du script, pas son attribut type — un hit reste un candidat à vérifier, pas une preuve (ex. une globale imposée par un script tiers comme Matomo est un candidat légitime, pas une erreur).",
+          "recommendation": "Envelopper le code dans une IIFE ou un module, ou scoper la variable dans la fonction qui l'utilise. Si la globale est nécessaire (script tiers), l'assigner explicitement en propriété d'un objet global existant plutôt qu'en variable nue.",
+          "rgesn_ref": "6.x",
+          "gr491_famille": "Front-end",
+          "tags": [
+            "javascript",
+            "portee",
             "maintenance"
           ]
         }

--- a/skills/green-claude/scripts/detect-implicit-globals.awk
+++ b/skills/green-claude/scripts/detect-implicit-globals.awk
@@ -1,0 +1,41 @@
+# Détecteur de variables globales implicites en JS/TS (ECO-FRONT-06) : une
+# déclaration var/let/const, ou une affectation sans mot-clé, au niveau
+# racine d'un fichier <script> classique (profondeur d'accolades 0) reste en
+# vie pour toute la durée de vie de la page et est visible par tout autre
+# script partageant ce contexte. Suit la profondeur des accolades : rien
+# n'est signalé à l'intérieur d'une fonction, d'une IIFE ou d'un bloc.
+#
+# Limite assumée : un module ES (<script type="module">) n'a pas cette
+# sémantique (le top-level y est déjà isolé au module) — ce détecteur ne
+# reçoit que le contenu du script, pas son attribut type, et ne peut donc
+# pas faire la différence. Un hit reste un candidat à vérifier, pas une
+# preuve.
+#
+# Sortie : "numéro_de_ligne:ligne" pour chaque déclaration/affectation
+# candidate au niveau racine.
+
+BEGIN { depth = 0 }
+
+{
+    line = $0
+    trimmed = line
+    gsub(/^[ \t]+/, "", trimmed)
+    gsub(/[ \t]+$/, "", trimmed)
+
+    is_comment_only = (trimmed ~ /^(\/\/|\*|\/\*)/)
+    is_declaration  = (trimmed ~ /^(var|let|const)[ \t]+[a-zA-Z_$]/)
+    # Affectation nue en tout début de ligne (pas de mot-clé, pas de point
+    # avant le nom -> exclut "foo.bar = " qui n'est pas une déclaration).
+    is_bare_assign  = (trimmed ~ /^[a-zA-Z_$][a-zA-Z0-9_$]*[ \t]*=[^=]/)
+
+    if (depth == 0 && !is_comment_only && (is_declaration || is_bare_assign)) {
+        printf "%d:%s\n", NR, line
+    }
+
+    n = length(line)
+    for (i = 1; i <= n; i++) {
+        c = substr(line, i, 1)
+        if (c == "{") depth++
+        else if (c == "}") depth--
+    }
+}

--- a/skills/green-claude/scripts/test-eco-audit.sh
+++ b/skills/green-claude/scripts/test-eco-audit.sh
@@ -168,4 +168,28 @@ echo "$OUT" | grep -q 'gestion erreur' && fail "code mort : faux positif (catch 
 N=$(echo "$OUT" | grep -c 'ECO-FRONT-05')
 [ "$N" -eq 1 ] || fail "code mort : attendu 1 seul hit sur ce fichier, trouvé $N"
 
-echo "OK - 9 verifications passees"
+# 10. ECO-FRONT-06 (globales implicites) : détecte var/affectation nue au
+# niveau racine d'un script, silencieux dans une IIFE/fonction, et ne
+# confond pas une affectation de propriété ("window.foo =", "obj.bar =")
+# avec une nouvelle globale.
+cat > "$TMP/globals.js" <<'EOF'
+var leaked = 1;
+foo = 2;
+window.bar = 3;
+(function() {
+  var scoped = 1;
+})();
+function helper() {
+  var localVar = 1;
+}
+obj.prop = 5;
+EOF
+OUT="$(bash eco-audit.sh "$TMP/globals.js")"
+echo "$OUT" | grep -q 'var leaked' || fail "globales : var au niveau racine non détecté"
+echo "$OUT" | grep -q 'foo = 2' || fail "globales : affectation nue au niveau racine non détectée"
+echo "$OUT" | grep -q 'window.bar' && fail "globales : faux positif sur une affectation de propriété (window.bar)"
+echo "$OUT" | grep -q 'var scoped' && fail "globales : faux positif sur une var dans une IIFE"
+echo "$OUT" | grep -q 'localVar' && fail "globales : faux positif sur une var dans une fonction"
+echo "$OUT" | grep -q 'obj.prop' && fail "globales : faux positif sur une affectation de propriété (obj.prop)"
+
+echo "OK - 10 verifications passees"


### PR DESCRIPTION
## Contexte

Deuxième volet de l'audit qualité JS/CSS demandé, après ECO-FRONT-05 (code mort) : une variable déclarée ou affectée sans mot-clé au premier niveau d'un script classique reste en vie pour toute la durée de la page et visible de tout autre script — retenue en mémoire plus longtemps que nécessaire, avec un risque de collision entre scripts.

## La règle

Nouveau détecteur (`scripts/detect-implicit-globals.awk`), même principe que les précédents : suit la profondeur des accolades, ne signale rien à l'intérieur d'une fonction ou d'une IIFE.

## Validation contre un vrai linter

ESLint (`no-implicit-globals`) sur le script Matomo de `docs/index.html` trouve exactement 1 finding : `var _paq = window._paq = window._paq || [];`. Le détecteur awk trouve exactement la même ligne sur le même fichier — cohérence confirmée entre l'heuristique et un vrai linter avant d'écrire la règle.

## Testé

`scripts/test-eco-audit.sh` passe à 10/10 :
- `var` et affectation nue au niveau racine → détectés
- `var` dans une IIFE, `var` dans une fonction → silencieux
- Affectation de propriété (`window.bar =`, `obj.prop =`) → silencieux, ne pas confondre avec une nouvelle globale

## Limite documentée

Un `<script type="module">` n'a pas cette sémantique de portée globale au premier niveau, mais le détecteur ne reçoit que le contenu du script, pas son attribut `type` — un hit reste un candidat. Une globale imposée par un script tiers (Matomo, etc.) en est un exemple légitime à confirmer plutôt qu'une erreur à corriger d'office. Documenté dans `SKILL.md` et dans la règle elle-même.

## Mis à jour en conséquence

38 règles au total désormais (était 37), `ECO-FRONT-06` dans la famille Frontend juste après `ECO-FRONT-05`.