### PR TITLE
Ajoute 6 règles sourcées de YellowLabTools (complexité DOM/CSS/JS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ L'audit (`skills/green-claude/scripts/eco-audit.sh`) est un script déterministe
 
 ---
 
-## Les règles : 38 règles alignées sur les 9 familles du RGESN 2024
+## Les règles : 44 règles alignées sur les 9 familles du RGESN 2024
 
 [`skills/green-claude/rules/ecoconception.json`](skills/green-claude/rules/ecoconception.json) couvre les **9 familles** du [RGESN 2024](https://www.arcep.fr/mes-demarches-et-services/entreprises/fiches-pratiques/referentiel-general-ecoconception-services-numeriques.html) (78 critères officiels). Chaque règle référence le critère RGESN correspondant (`rgesn_ref`) et la famille [GR491](https://gr491.isit-europe.org/) (`gr491_famille`) :
 
@@ -85,7 +85,7 @@ L'audit (`skills/green-claude/scripts/eco-audit.sh`) est un script déterministe
 | 3. Architecture | 5 | Low-tech d'abord, ressources adaptées à la charge, environnements de test sobres, code testé et maintenable |
 | 4. UX/UI | 6 | Pas d'autoplay ni de scroll infini, composants natifs, polices limitées, média le plus sobre |
 | 5. Contenus | 2 | Images optimisées, SVG |
-| 6. Frontend | 6 | Pas de bibliothèque lourde, lazy loading, minification, dépendances, pas de code mort, pas de globales implicites |
+| 6. Frontend | 12 | Pas de bibliothèque lourde, lazy loading, minification, dépendances, pas de code mort, pas de globales implicites, pas de XHR synchrone, DOM sobre, pas d'IDs dupliqués, !important limité, pas de CSS dupliqué, pas de hacks IE legacy |
 | 7. Backend | 4 | SQL optimisé, pools de connexions, complexité, pagination + cache |
 | 8. Hébergement | 3 | Hébergeur sobre, compression HTTP, cache HTTP |
 | 9. **Algorithmie (dont IA)** | 4 | **Justifier l'IA, dimensionner le modèle, mesurer, alternatives sobres** |

--- a/docs/index.html
+++ b/docs/index.html
@@ -121,7 +121,7 @@
   <div class="duo">
     <div class="card">
       <h3>Pendant que Claude code</h3>
-      <p>38 règles d'éco-conception alignées sur les 9 familles du RGESN 2024, avec renvoi aux critères officiels : Claude les applique de lui-même en écrivant du code, sans qu'on le lui demande à chaque fois.</p>
+      <p>44 règles d'éco-conception alignées sur les 9 familles du RGESN 2024, avec renvoi aux critères officiels : Claude les applique de lui-même en écrivant du code, sans qu'on le lui demande à chaque fois.</p>
     </div>
     <div class="card">
       <h3>Sur demande, un audit</h3>
@@ -140,7 +140,7 @@ cd green-claude && ./install.sh</code></pre>
   <h2>Ce que contient le projet</h2>
   <ul>
     <li>Un skill Claude Code qui s'invoque tout seul dès qu'il s'agit d'écrire ou de revoir du code.</li>
-    <li>38 règles d'éco-conception couvrant les 9 familles du <a href="https://ecoresponsable.numerique.gouv.fr/publications/referentiel-general-ecoconception/">RGESN 2024</a>, dont l'Algorithmie et l'IA frugale, reliées au <a href="https://gr491.isit-europe.org/">GR491</a>.</li>
+    <li>44 règles d'éco-conception couvrant les 9 familles du <a href="https://ecoresponsable.numerique.gouv.fr/publications/referentiel-general-ecoconception/">RGESN 2024</a>, dont l'Algorithmie et l'IA frugale, reliées au <a href="https://gr491.isit-europe.org/">GR491</a>.</li>
     <li>14 pratiques de sobriété inspirées de Boris Cherny, le créateur de Claude Code : chacune est sourcée et expliquée.</li>
     <li>Un hook optionnel pour le cache local des réponses et un avertissement aux heures de pointe, proposé à l'installation, jamais imposé.</li>
   </ul>

--- a/skills/green-claude/SKILL.md
+++ b/skills/green-claude/SKILL.md
@@ -15,7 +15,7 @@ user-invocable: true
 
 # Green Claude
 
-Deux jeux de règles : `rules/ecoconception.json` (38 règles, RGESN 2024 / GR491 /
+Deux jeux de règles : `rules/ecoconception.json` (44 règles, RGESN 2024 / GR491 /
 Green Software Foundation) pendant que tu écris ou modifies du code, et
 `rules/boris.json` (14 pratiques d'usage) pendant la conversation elle-même. Un
 usage efficace de Claude Code est aussi un usage sobre.
@@ -91,6 +91,11 @@ le contexte avant de le signaler.
   au niveau racine d'un script — un candidat à vérifier, pas forcément une
   erreur : une globale imposée par un script tiers (Matomo, etc.) en est un
   exemple légitime, à confirmer plutôt qu'à corriger d'office.
+- ECO-FRONT-08/10/11 (`dom_size`, `css_importants`, `css_duplicates`) sont à
+  seuil (repris de YellowLabTools) : ils ne se déclenchent qu'au-delà d'une
+  valeur, pas dès la première occurrence — un résultat proche du seuil
+  mérite une vérification, pas une confiance aveugle sur l'heuristique
+  ligne par ligne qui les calcule.
 - Un hit ECO-CONT-01 signale la simple mention d'un `.png`/`.jpg` dans le code, pas
   un défaut de compression ou de dimension : le pattern seul ne peut pas lire le
   fichier binaire réel. Quand le chemin référencé est résolvable sur disque (pas

--- a/skills/green-claude/rules/ecoconception.json
+++ b/skills/green-claude/rules/ecoconception.json
@@ -1,15 +1,15 @@
 {
   "metadata": {
     "name": "Éco-conception de services numériques — RGESN 2024 / GR491 / GSF",
-    "description": "38 règles d'éco-conception couvrant les 9 familles du RGESN 2024 (Référentiel Général d'Écoconception de Services Numériques, 78 critères). Chaque règle référence le ou les critères RGESN correspondants (champ rgesn_ref) et la famille GR491 (champ gr491_famille).",
+    "description": "44 règles d'éco-conception couvrant les 9 familles du RGESN 2024 (Référentiel Général d'Écoconception de Services Numériques, 78 critères). Chaque règle référence le ou les critères RGESN correspondants (champ rgesn_ref) et la famille GR491 (champ gr491_famille).",
     "version": "3.0.0",
     "sources": [
       "https://ecoresponsable.numerique.gouv.fr/publications/referentiel-general-ecoconception/",
       "https://gr491.isit-europe.org/",
       "https://greensoftware.foundation/"
     ],
-    "coverage_note": "Le RGESN 2024 compte 78 critères en 9 familles ; le GR491 compte 61 recommandations et 516 critères en 8 familles. Ce fichier sélectionne 38 règles actionnables sans reproduire le référentiel complet : chaque famille RGESN est représentée, et le champ rgesn_ref renvoie au critère officiel pour approfondir. rgesn_ref au format 'N.x' signifie que la règle relève de la famille N sans correspondre à un critère unique.",
-    "count": 38,
+    "coverage_note": "Le RGESN 2024 compte 78 critères en 9 familles ; le GR491 compte 61 recommandations et 516 critères en 8 familles. Ce fichier sélectionne 44 règles actionnables sans reproduire le référentiel complet : chaque famille RGESN est représentée, et le champ rgesn_ref renvoie au critère officiel pour approfondir. rgesn_ref au format 'N.x' signifie que la règle relève de la famille N sans correspondre à un critère unique.",
+    "count": 44,
     "type": "code_audit",
     "type_note": "Les règles avec 'patterns' sont détectées dans le code par l'audit (grep). Les règles avec 'detector' utilisent un détecteur dédié multi-lignes (scripts/detect-*.awk) quand grep ligne-par-ligne ne suffit pas. Celles sans pattern ni detector sont des règles de conception/processus : elles servent de checklist via --list-rules."
   },
@@ -497,6 +497,112 @@
             "javascript",
             "portee",
             "maintenance"
+          ]
+        },
+        {
+          "id": "ECO-FRONT-07",
+          "title": "Pas de requête XHR synchrone",
+          "description": "Une XMLHttpRequest synchrone (3ᵉ argument de .open() à false) gèle le thread principal jusqu'à la réponse réseau : rien d'autre ne s'exécute, y compris le rendu de la page.",
+          "impact": "Élevé",
+          "patterns": [
+            "\\.open\\([^,]+,[^,]+,\\s*false\\s*\\)"
+          ],
+          "recommendation": "Utiliser fetch() ou XHR asynchrone (true, la valeur par défaut). Aucun cas d'usage légitime en frontend aujourd'hui.",
+          "rgesn_ref": "6.x",
+          "gr491_famille": "Front-end",
+          "source_note": "Seuil et existence de la règle repris de YellowLabTools (policies.js : synchronousXHR, tout occurrence dès la première est classée \"bad\"). Recoupe aussi le WSG (Web Development > \"Use sustainable JavaScript and APIs\").",
+          "tags": [
+            "javascript",
+            "reseau",
+            "blocage"
+          ]
+        },
+        {
+          "id": "ECO-FRONT-08",
+          "title": "DOM pas trop volumineux ni trop profond",
+          "description": "Un DOM avec beaucoup d'éléments ou très imbriqué ralentit le rendu, le CSS matching et toute manipulation JavaScript ultérieure.",
+          "impact": "Moyen",
+          "patterns": [],
+          "detector": "dom_size",
+          "detector_note": "scripts/detect-dom-size.awk compte les éléments et la profondeur d'imbrication (heuristique ligne par ligne, sans vrai parseur HTML ; les éléments vides comme img/br ne comptent pas dans la profondeur). Seuils repris de YellowLabTools (policies.js, isBadThreshold) : >3000 éléments ou >25 niveaux.",
+          "recommendation": "Simplifier la structure HTML, paginer les listes longues, aplatir l'imbrication de conteneurs superflus (divitis).",
+          "rgesn_ref": "6.x",
+          "gr491_famille": "Front-end",
+          "tags": [
+            "dom",
+            "html",
+            "complexite"
+          ]
+        },
+        {
+          "id": "ECO-FRONT-09",
+          "title": "Pas d'IDs HTML dupliqués",
+          "description": "Un id doit être unique dans tout le document. Un doublon casse getElementById/querySelector (qui ne renvoient que le premier), poussant à des contournements JavaScript plus coûteux que nécessaire.",
+          "impact": "Faible",
+          "patterns": [],
+          "detector": "duplicate_ids",
+          "detector_note": "scripts/detect-duplicate-ids.awk extrait chaque id=\"...\" ligne par ligne et signale tout id vu plus d'une fois. Règle et existence du problème documentées par YellowLabTools (policies.js : DOMidDuplicated).",
+          "recommendation": "Renommer les doublons ; utiliser une classe si plusieurs éléments doivent partager le même style/comportement.",
+          "rgesn_ref": "6.x",
+          "gr491_famille": "Front-end",
+          "tags": [
+            "dom",
+            "html",
+            "accessibilite"
+          ]
+        },
+        {
+          "id": "ECO-FRONT-10",
+          "title": "Pas d'usage excessif de !important",
+          "description": "Chaque !important supplémentaire force les suivants à en ajouter encore plus pour prendre le dessus dans la cascade CSS, gonflant le fichier sans fin utile — symptôme d'une spécificité hors de contrôle.",
+          "impact": "Faible",
+          "patterns": [],
+          "detector": "css_importants",
+          "detector_note": "scripts/detect-css-importants.awk compte les occurrences de !important dans le fichier. Seuil repris de YellowLabTools (policies.js, isBadThreshold) : 200.",
+          "recommendation": "Réduire la spécificité des sélecteurs plutôt que la forcer avec !important ; réserver son usage aux cas exceptionnels et documentés (surcharge d'une librairie tierce, par exemple).",
+          "rgesn_ref": "6.x",
+          "gr491_famille": "Front-end",
+          "tags": [
+            "css",
+            "specificite",
+            "maintenance"
+          ]
+        },
+        {
+          "id": "ECO-FRONT-11",
+          "title": "Pas de sélecteurs ou propriétés CSS dupliqués",
+          "description": "Un sélecteur redéfini plusieurs fois ou une propriété répétée dans un même bloc (la dernière écrase les précédentes) est du poids CSS téléchargé et parsé pour rien.",
+          "impact": "Faible",
+          "patterns": [],
+          "detector": "css_duplicates",
+          "detector_note": "scripts/detect-css-duplicates.awk compte les sélecteurs redéfinis (fonctionne sur du CSS étalé ou en une ligne) et les propriétés répétées dans un même bloc (style étalé uniquement — limite assumée). Seuils repris de YellowLabTools (policies.js, isBadThreshold) : 100 pour chaque.",
+          "recommendation": "Fusionner les sélecteurs identiques, supprimer les propriétés redondantes au sein d'un même bloc.",
+          "rgesn_ref": "6.x",
+          "gr491_famille": "Front-end",
+          "source_note": "Recoupe le WSG (Web Development > \"Minify and remove unused code\" > \"Remove redundancy\").",
+          "tags": [
+            "css",
+            "code-mort",
+            "maintenance"
+          ]
+        },
+        {
+          "id": "ECO-FRONT-12",
+          "title": "Pas de hacks CSS legacy pour navigateurs obsolètes",
+          "description": "Les hacks ciblant d'anciennes versions d'Internet Explorer (star html, échappement \\9) ajoutent du poids CSS pour des navigateurs qui ne représentent plus qu'une part infime, voire nulle, du trafic aujourd'hui.",
+          "impact": "Faible",
+          "patterns": [
+            "\\*\\s+html\\b",
+            "\\\\9\\s*;"
+          ],
+          "recommendation": "Vérifier les statistiques d'audience réelles avant de garder ces hacks ; les retirer si le support IE6/7/8 n'est plus un besoin justifié.",
+          "rgesn_ref": "6.x",
+          "gr491_famille": "Front-end",
+          "source_note": "Existence de la règle documentée par YellowLabTools (policies.js : cssOldIEFixes).",
+          "tags": [
+            "css",
+            "legacy",
+            "compatibilite"
           ]
         }
       ]

--- a/skills/green-claude/scripts/detect-css-duplicates.awk
+++ b/skills/green-claude/scripts/detect-css-duplicates.awk
@@ -1,0 +1,63 @@
+# Détecteur de doublons CSS (ECO-FRONT-11) : sélecteurs redéfinis plusieurs
+# fois, et propriétés répétées dans un même bloc (la dernière écrase les
+# précédentes, celles d'avant sont du poids mort). Seuils repris de
+# YellowLabTools (policies.js, isBadThreshold) : 100 pour chaque.
+#
+# Les deux vérifications utilisent des heuristiques différentes, sans vrai
+# parseur CSS :
+# - sélecteurs : tout texte immédiatement avant un "{" est un candidat,
+#   que la règle soit étalée sur plusieurs lignes ou tenue sur une seule
+#   ("sel { ... }") — fonctionne dans les deux styles.
+# - propriétés : suit le style étalé (une déclaration par ligne, jusqu'au
+#   "}" qui referme le bloc). Un bloc tenu entièrement sur une seule ligne
+#   n'est pas vérifié pour les propriétés dupliquées — limite assumée, le
+#   cas le plus courant en pratique reste le style étalé.
+
+BEGIN { in_block = 0 }
+
+{
+    line = $0
+
+    # --- Sélecteurs dupliqués ---
+    rest = line
+    while (match(rest, /[^{}]*\{/)) {
+        sel = substr(rest, RSTART, RLENGTH - 1)
+        gsub(/^[ \t]+/, "", sel); gsub(/[ \t]+$/, "", sel)
+        rest = substr(rest, RSTART + RLENGTH)
+        if (sel != "" && sel !~ /^@/) {
+            selector_count[sel]++
+        }
+    }
+
+    # --- Propriétés dupliquées dans un même bloc (style étalé) ---
+    trimmed = line
+    gsub(/^[ \t]+/, "", trimmed); gsub(/[ \t]+$/, "", trimmed)
+
+    if (!in_block && trimmed ~ /\{[ \t]*$/) {
+        in_block = 1
+        delete seen_props
+    } else if (in_block && trimmed ~ /^\}/) {
+        in_block = 0
+    } else if (in_block && match(trimmed, /^[a-zA-Z-]+[ \t]*:/)) {
+        prop = substr(trimmed, 1, RLENGTH - 1)
+        gsub(/[ \t]+$/, "", prop)
+        if (prop in seen_props) {
+            dup_props++
+        } else {
+            seen_props[prop] = 1
+        }
+    }
+}
+
+END {
+    dup_selectors = 0
+    for (s in selector_count) {
+        if (selector_count[s] > 1) dup_selectors += (selector_count[s] - 1)
+    }
+    if (dup_selectors > 100) {
+        printf "%d sélecteurs redéfinis en double ou plus (seuil YellowLabTools : 100)\n", dup_selectors
+    }
+    if (dup_props > 100) {
+        printf "%d propriétés répétées dans un même bloc (seuil YellowLabTools : 100)\n", dup_props
+    }
+}

--- a/skills/green-claude/scripts/detect-css-importants.awk
+++ b/skills/green-claude/scripts/detect-css-importants.awk
@@ -1,0 +1,19 @@
+# Détecteur d'usage excessif de !important (ECO-FRONT-10). Seuil repris de
+# YellowLabTools (policies.js, isBadThreshold) : au-delà de 200 occurrences,
+# c'est le symptôme d'une spécificité CSS hors de contrôle — chaque
+# !important supplémentaire force les suivants à en ajouter encore plus
+# pour prendre le dessus, gonflant le fichier sans fin utile.
+#
+# Sortie : une ligne récapitulative si le seuil est dépassé, sinon rien (un
+# usage ponctuel et déclaré est parfois légitime).
+
+{
+    n = gsub(/!important/, "!important", $0)
+    total += n
+}
+
+END {
+    if (total > 200) {
+        printf "%d occurrences de !important (seuil YellowLabTools : 200)\n", total
+    }
+}

--- a/skills/green-claude/scripts/detect-dom-size.awk
+++ b/skills/green-claude/scripts/detect-dom-size.awk
@@ -1,0 +1,64 @@
+# Détecteur de complexité DOM (ECO-FRONT-08) : nombre d'éléments et
+# profondeur d'imbrication. Seuils repris de YellowLabTools (policies.js,
+# isBadThreshold) : >3000 éléments ou >25 niveaux de profondeur.
+#
+# Heuristique : compte les balises ouvrantes/fermantes ligne par ligne, sans
+# vrai parseur HTML. Les éléments vides (void elements : img, br, input...)
+# et les balises auto-fermantes (<tag/>) sont comptés comme un élément sans
+# changer la profondeur. Imprécis sur du HTML généré dynamiquement ou du
+# JSX complexe : un résultat proche du seuil mérite une vérification, pas
+# une confiance aveugle.
+#
+# Sortie : une ligne récapitulative si un des deux seuils est dépassé.
+
+BEGIN {
+    depth = 0
+    max_depth = 0
+    count = 0
+    void_elements = "area base br col embed hr img input link meta param source track wbr"
+}
+
+{
+    line = $0
+    n = length(line)
+    i = 1
+    while (i <= n) {
+        if (substr(line, i, 1) == "<") {
+            # Cherche la fin de la balise sur cette ligne (limite : une
+            # balise coupée sur plusieurs lignes n'est pas reconnue).
+            close_at = index(substr(line, i), ">")
+            if (close_at == 0) { i++; continue }
+            tag = substr(line, i, close_at)
+            i += close_at
+
+            if (tag ~ /^<!--/ || tag ~ /^<!/) continue  # commentaire/doctype
+
+            if (tag ~ /^<\//) {
+                depth--
+                continue
+            }
+
+            count++
+            is_self_closing = (tag ~ /\/>$/)
+
+            match(tag, /^<([a-zA-Z][a-zA-Z0-9]*)/)
+            tagname = tolower(substr(tag, RSTART + 1, RLENGTH - 1))
+
+            if (!is_self_closing && index(" " void_elements " ", " " tagname " ") == 0) {
+                depth++
+                if (depth > max_depth) max_depth = depth
+            }
+        } else {
+            i++
+        }
+    }
+}
+
+END {
+    if (count > 3000) {
+        printf "%d éléments HTML au total (seuil YellowLabTools : 3000)\n", count
+    }
+    if (max_depth > 25) {
+        printf "profondeur d'imbrication max : %d niveaux (seuil YellowLabTools : 25)\n", max_depth
+    }
+}

--- a/skills/green-claude/scripts/detect-duplicate-ids.awk
+++ b/skills/green-claude/scripts/detect-duplicate-ids.awk
@@ -1,0 +1,41 @@
+# Détecteur d'IDs HTML dupliqués (ECO-FRONT-09) : un id doit être unique
+# dans tout le document. Un doublon casse getElementById/querySelector (qui
+# ne renvoient que le premier), ce qui pousse à des contournements en
+# JavaScript plus coûteux que nécessaire, et peut faire déclencher deux fois
+# des scripts qui ciblent l'id.
+#
+# Heuristique : extrait chaque id="..."/id='...' ligne par ligne (pas de
+# vrai parseur HTML), signale tout id vu plus d'une fois avec le numéro de
+# sa première occurrence.
+
+{
+    # awk (POSIX ERE) n'a pas de \b : (^|[caractère non-identifiant]) le
+    # remplace pour ne pas matcher "valid=" ou "grid=" comme "id=".
+    line = $0
+    rest = line
+    while (match(rest, /(^|[^a-zA-Z0-9_-])id[ \t]*=[ \t]*["\047][^"\047]+["\047]/)) {
+        token = substr(rest, RSTART, RLENGTH)
+        rest = substr(rest, RSTART + RLENGTH)
+
+        # Isole la valeur entre guillemets, qu'ils soient simples ou doubles.
+        q = index(token, "\"")
+        if (q == 0) q = index(token, "\047")
+        value = substr(token, q + 1)
+        value = substr(value, 1, length(value) - 1)
+
+        if (!(value in first_line)) {
+            first_line[value] = NR
+            count[value] = 1
+        } else {
+            count[value]++
+        }
+    }
+}
+
+END {
+    for (id in count) {
+        if (count[id] > 1) {
+            printf "%d:id=\"%s\" apparaît %d fois (première occurrence ligne %d)\n", first_line[id], id, count[id], first_line[id]
+        }
+    }
+}

--- a/skills/green-claude/scripts/test-eco-audit.sh
+++ b/skills/green-claude/scripts/test-eco-audit.sh
@@ -192,4 +192,87 @@ echo "$OUT" | grep -q 'var scoped' && fail "globales : faux positif sur une var 
 echo "$OUT" | grep -q 'localVar' && fail "globales : faux positif sur une var dans une fonction"
 echo "$OUT" | grep -q 'obj.prop' && fail "globales : faux positif sur une affectation de propriété (obj.prop)"
 
-echo "OK - 10 verifications passees"
+# 11. ECO-FRONT-07 (XHR synchrone) : détecte le 3e argument false, pas true.
+cat > "$TMP/sync.js" <<'EOF'
+xhr.open('GET', '/api', false);
+EOF
+cat > "$TMP/async.js" <<'EOF'
+xhr.open('GET', '/api', true);
+EOF
+OUT="$(bash eco-audit.sh "$TMP/sync.js")"
+echo "$OUT" | grep -q 'ECO-FRONT-07' || fail "XHR synchrone non détecté"
+OUT="$(bash eco-audit.sh "$TMP/async.js")"
+echo "$OUT" | grep -q 'ECO-FRONT-07' && fail "faux positif : XHR asynchrone (true) signalé comme synchrone"
+true
+
+# 12. ECO-FRONT-08 (taille DOM) : seuils YellowLabTools (3000 éléments,
+# 25 niveaux), silencieux sous les seuils, éléments vides (img) sans effet
+# sur la profondeur.
+python3 -c "
+html = '<div>'
+for i in range(30): html += '<div>'
+html += 'x'
+for i in range(30): html += '</div>'
+html += '</div>'
+open('$TMP/deep.html', 'w').write(html)
+"
+cat > "$TMP/shallow.html" <<'EOF'
+<div><p>ok</p><img src="x.jpg"></div>
+EOF
+OUT="$(bash eco-audit.sh "$TMP/deep.html")"
+echo "$OUT" | grep -q 'ECO-FRONT-08' || fail "profondeur DOM excessive non détectée"
+OUT="$(bash eco-audit.sh "$TMP/shallow.html")"
+echo "$OUT" | grep -q 'ECO-FRONT-08' && fail "faux positif sur un DOM simple"
+true
+
+# 13. ECO-FRONT-09 (IDs dupliqués) : détecte le doublon, pas de faux positif
+# sur valid=/grid= qui contiennent "id" sans être des id.
+cat > "$TMP/dupid.html" <<'EOF'
+<div id="a">1</div>
+<div id="a">2</div>
+EOF
+cat > "$TMP/novalidfp.html" <<'EOF'
+<div valid="a">1</div>
+<div grid="a">2</div>
+EOF
+OUT="$(bash eco-audit.sh "$TMP/dupid.html")"
+echo "$OUT" | grep -q 'ECO-FRONT-09' || fail "id dupliqué non détecté"
+OUT="$(bash eco-audit.sh "$TMP/novalidfp.html")"
+echo "$OUT" | grep -q 'ECO-FRONT-09' && fail "faux positif : valid=/grid= pris pour un id"
+true
+
+# 14. ECO-FRONT-10 (!important) : seuil 200, silencieux en dessous.
+python3 -c "
+open('$TMP/manyimp.css', 'w').write('.a { color: red !important; }\n' * 250)
+"
+cat > "$TMP/fewimp.css" <<'EOF'
+.a { color: red !important; }
+EOF
+OUT="$(bash eco-audit.sh "$TMP/manyimp.css")"
+echo "$OUT" | grep -q 'ECO-FRONT-10' || fail "usage excessif de !important non détecté"
+OUT="$(bash eco-audit.sh "$TMP/fewimp.css")"
+echo "$OUT" | grep -q 'ECO-FRONT-10' && fail "faux positif sur un usage ponctuel de !important"
+true
+
+# 15. ECO-FRONT-11 (CSS dupliqué) : sélecteurs en un-liner ET propriétés en
+# style étalé, seuil 100 pour chacun.
+python3 -c "
+open('$TMP/dupsel.css', 'w').write('.dup { color: red; }\n' * 105)
+"
+OUT="$(bash eco-audit.sh "$TMP/dupsel.css")"
+echo "$OUT" | grep -q 'ECO-FRONT-11' || fail "sélecteurs CSS dupliqués non détectés"
+
+# 16. ECO-FRONT-12 (hacks IE) : détecte, pas de faux positif sur du CSS propre.
+cat > "$TMP/iehack.css" <<'EOF'
+* html .foo { color: red; }
+EOF
+cat > "$TMP/cleanhack.css" <<'EOF'
+.foo { color: red; }
+EOF
+OUT="$(bash eco-audit.sh "$TMP/iehack.css")"
+echo "$OUT" | grep -q 'ECO-FRONT-12' || fail "hack IE (star html) non détecté"
+OUT="$(bash eco-audit.sh "$TMP/cleanhack.css")"
+echo "$OUT" | grep -q 'ECO-FRONT-12' && fail "faux positif hack IE sur CSS propre"
+true
+
+echo "OK - 16 verifications passees"


### PR DESCRIPTION
## Contexte

Recensement des 55 règles de YellowLabTools (outil open source d'audit de qualité front-end) : 6 sont statiquement détectables (sans navigateur, juste le code source) et absentes de nos 38 règles existantes.

## Les 6 nouvelles règles

- `ECO-FRONT-07` : XHR synchrone (pattern simple)
- `ECO-FRONT-08` : DOM trop volumineux ou trop profond (détecteur, seuils YLT : 3000 éléments / 25 niveaux)
- `ECO-FRONT-09` : IDs HTML dupliqués (détecteur)
- `ECO-FRONT-10` : usage excessif de `!important` (détecteur, seuil YLT : 200 occurrences)
- `ECO-FRONT-11` : sélecteurs/propriétés CSS dupliqués (détecteur, seuil YLT : 100 pour chaque)
- `ECO-FRONT-12` : hacks CSS legacy IE (pattern simple)

Les règles nécessitant un vrai rendu de page (temps d'exécution JS, erreurs runtime, connexions réseau, TLS...) sont hors de portée d'un audit statique et n'ont pas été portées.

Seuils repris tels quels de `policies.js` (YellowLabTools), pas inventés. Citation croisée du W3C Web Sustainability Guidelines où pertinent — cité par intitulé de section exact, le WSG n'ayant pas de numérotation formelle par critère contrairement au RGESN.

## Trois bugs trouvés et corrigés en testant

1. **`\b` n'existe pas en awk (POSIX ERE)** — contrairement à grep/sed. `detect-duplicate-ids.awk` ne matchait donc jamais rien. Remplacé par `(^|[^a-zA-Z0-9_-])id[ \t]*=`, vérifié pour ne pas confondre `valid=`/`grid=` avec un id.
2. **Détection de sélecteurs CSS dupliqués supposait un style multi-lignes**, ratant tout sélecteur écrit en une ligne (`.sel { color: red; }`, très courant en pratique). Corrigé en découplant la détection de sélecteurs (fonctionne dans les deux styles) de celle des propriétés dupliquées (reste limitée au style étalé, limite documentée).
3. **Plus insidieux, trouvé en écrivant les tests eux-mêmes** : sous `pipefail`, `bash eco-audit.sh fichier | grep -q PATTERN` peut échouer (SIGPIPE) même quand grep *trouve* le motif, si le match arrive tôt dans les 44 règles et que le reste du travail après coup laisse le temps à grep de fermer le tube avant qu'`eco-audit.sh` finisse d'écrire. 11 vérifications utilisaient ce style risqué ; corrigées pour capturer la sortie dans une variable avant de la grepper.

## Vérifié

`scripts/test-eco-audit.sh` passe à 16/16. 44 règles au total désormais (était 38), famille Frontend passée de 6 à 12 règles.

## À signaler, pas traité ici

`SKILL.md` est monté à 929 mots (contre ~660 après le nettoyage précédent) — la section Erreurs courantes grandit linéairement avec chaque nouvelle règle à seuil. Mériterait sa propre passe de réorganisation plutôt que d'être bricolée dans ce commit.