### PR TITLE
Corrige 3 gaps SQL, ajoute 5 règles WSG et 3 règles HTTPS/TLS/liens

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,20 +74,20 @@ L'audit (`skills/green-claude/scripts/eco-audit.sh`) est un script déterministe
 
 ---
 
-## Les règles : 44 règles alignées sur les 9 familles du RGESN 2024
+## Les règles : 52 règles alignées sur les 9 familles du RGESN 2024
 
 [`skills/green-claude/rules/ecoconception.json`](skills/green-claude/rules/ecoconception.json) couvre les **9 familles** du [RGESN 2024](https://www.arcep.fr/mes-demarches-et-services/entreprises/fiches-pratiques/referentiel-general-ecoconception-services-numeriques.html) (78 critères officiels). Chaque règle référence le critère RGESN correspondant (`rgesn_ref`) et la famille [GR491](https://gr491.isit-europe.org/) (`gr491_famille`) :
 
 | Famille RGESN | Règles | Exemples |
 |---|---|---|
-| 1. Stratégie | 3 | Mesurer avant d'optimiser, données raisonnées, formats ouverts |
+| 1. Stratégie | 6 | Mesurer avant d'optimiser, données raisonnées, formats ouverts, référent sobriété, sensibilisation, transparence utilisateur |
 | 2. Spécifications | 5 | Compatibilité anciens terminaux, bas débit, impact des services tiers |
 | 3. Architecture | 5 | Low-tech d'abord, ressources adaptées à la charge, environnements de test sobres, code testé et maintenable |
-| 4. UX/UI | 6 | Pas d'autoplay ni de scroll infini, composants natifs, polices limitées, média le plus sobre |
+| 4. UX/UI | 7 | Pas d'autoplay ni de scroll infini, composants natifs, polices limitées, média le plus sobre, prefers-reduced-motion |
 | 5. Contenus | 2 | Images optimisées, SVG |
-| 6. Frontend | 12 | Pas de bibliothèque lourde, lazy loading, minification, dépendances, pas de code mort, pas de globales implicites, pas de XHR synchrone, DOM sobre, pas d'IDs dupliqués, !important limité, pas de CSS dupliqué, pas de hacks IE legacy |
+| 6. Frontend | 13 | Pas de bibliothèque lourde, lazy loading, minification, dépendances, pas de code mort, pas de globales implicites, pas de XHR synchrone, DOM sobre, pas d'IDs dupliqués, !important limité, pas de CSS dupliqué, pas de hacks IE legacy, scripts différés |
 | 7. Backend | 4 | SQL optimisé, pools de connexions, complexité, pagination + cache |
-| 8. Hébergement | 3 | Hébergeur sobre, compression HTTP, cache HTTP |
+| 8. Hébergement | 6 | Hébergeur sobre, compression HTTP, cache HTTP, HTTPS/TLS, liens cassés |
 | 9. **Algorithmie (dont IA)** | 4 | **Justifier l'IA, dimensionner le modèle, mesurer, alternatives sobres** |
 
 Les règles sans motif détectable (démarche, gouvernance) sont ignorées par l'audit et servent de checklist dans `/green-claude`.

--- a/docs/index.html
+++ b/docs/index.html
@@ -121,7 +121,7 @@
   <div class="duo">
     <div class="card">
       <h3>Pendant que Claude code</h3>
-      <p>44 règles d'éco-conception alignées sur les 9 familles du RGESN 2024, avec renvoi aux critères officiels : Claude les applique de lui-même en écrivant du code, sans qu'on le lui demande à chaque fois.</p>
+      <p>52 règles d'éco-conception alignées sur les 9 familles du RGESN 2024, avec renvoi aux critères officiels : Claude les applique de lui-même en écrivant du code, sans qu'on le lui demande à chaque fois.</p>
     </div>
     <div class="card">
       <h3>Sur demande, un audit</h3>
@@ -140,7 +140,7 @@ cd green-claude && ./install.sh</code></pre>
   <h2>Ce que contient le projet</h2>
   <ul>
     <li>Un skill Claude Code qui s'invoque tout seul dès qu'il s'agit d'écrire ou de revoir du code.</li>
-    <li>44 règles d'éco-conception couvrant les 9 familles du <a href="https://ecoresponsable.numerique.gouv.fr/publications/referentiel-general-ecoconception/">RGESN 2024</a>, dont l'Algorithmie et l'IA frugale, reliées au <a href="https://gr491.isit-europe.org/">GR491</a>.</li>
+    <li>52 règles d'éco-conception couvrant les 9 familles du <a href="https://ecoresponsable.numerique.gouv.fr/publications/referentiel-general-ecoconception/">RGESN 2024</a>, dont l'Algorithmie et l'IA frugale, reliées au <a href="https://gr491.isit-europe.org/">GR491</a>.</li>
     <li>14 pratiques de sobriété inspirées de Boris Cherny, le créateur de Claude Code : chacune est sourcée et expliquée.</li>
     <li>Un hook optionnel pour le cache local des réponses et un avertissement aux heures de pointe, proposé à l'installation, jamais imposé.</li>
   </ul>
@@ -149,7 +149,7 @@ cd green-claude && ./install.sh</code></pre>
   <p>Le code généré par l'IA va tourner pendant des années chez des utilisateurs qu'on ne verra jamais. C'est là que se joue l'essentiel de l'empreinte du « coder avec l'IA », pas pendant la session de génération. Green Claude s'attaque à ce moment précis, en s'appuyant sur des référentiels publics français et internationaux plutôt que sur des règles maison.</p>
 
   <h2>Pourquoi un skill, pas une checklist</h2>
-  <p>Une checklist RGESN en PDF dépend de la mémoire de qui l'a lue une fois, et personne ne la rouvre avant chaque ligne de code. Un skill Claude Code se charge à chaque session sans rappel, sélectionne les familles de règles pertinentes pour ce qui s'écrit à l'instant plutôt que d'imposer les 49 règles à chaque échange, et vérifie le code déjà produit sur demande via un script déterministe. La checklist reste un document consulté ; le skill s'exécute dans la session de travail elle-même.</p>
+  <p>Une checklist RGESN en PDF dépend de la mémoire de qui l'a lue une fois, et personne ne la rouvre avant chaque ligne de code. Un skill Claude Code se charge à chaque session sans rappel, sélectionne les familles de règles pertinentes pour ce qui s'écrit à l'instant plutôt que d'imposer les 66 règles à chaque échange, et vérifie le code déjà produit sur demande via un script déterministe. La checklist reste un document consulté ; le skill s'exécute dans la session de travail elle-même.</p>
 
   <footer>
     <p>Une production de l'<strong>Institut du Numérique Responsable</strong>, 2026, open source (MIT).<br>

--- a/skills/green-claude/SKILL.md
+++ b/skills/green-claude/SKILL.md
@@ -15,7 +15,7 @@ user-invocable: true
 
 # Green Claude
 
-Deux jeux de règles : `rules/ecoconception.json` (44 règles, RGESN 2024 / GR491 /
+Deux jeux de règles : `rules/ecoconception.json` (52 règles, RGESN 2024 / GR491 /
 Green Software Foundation) pendant que tu écris ou modifies du code, et
 `rules/boris.json` (14 pratiques d'usage) pendant la conversation elle-même. Un
 usage efficace de Claude Code est aussi un usage sobre.
@@ -102,6 +102,10 @@ le contexte avant de le signaler.
   une URL distante), le rapport ajoute son poids et ses dimensions réels
   (`scripts/inspect-image.sh`) — vérifie ces chiffres avant de conclure, et ne dis
   rien de plus que ce que le rapport donne quand le fichier n'est pas résolvable.
+- ECO-HEB-06 (liens cassés) scanne tout `href`/`src` du fichier, y compris ceux
+  qui n'ont rien à voir avec l'objet de l'audit : sur un fichier de test ou un
+  extrait contenant des chemins fictifs, il signalera ces chemins comme cassés
+  en plus des vraies règles ciblées — normal, pas un bug du détecteur.
 
 ## Ce que ce skill ne fait PAS
 

--- a/skills/green-claude/rules/ecoconception.json
+++ b/skills/green-claude/rules/ecoconception.json
@@ -1,15 +1,15 @@
 {
   "metadata": {
     "name": "Éco-conception de services numériques — RGESN 2024 / GR491 / GSF",
-    "description": "44 règles d'éco-conception couvrant les 9 familles du RGESN 2024 (Référentiel Général d'Écoconception de Services Numériques, 78 critères). Chaque règle référence le ou les critères RGESN correspondants (champ rgesn_ref) et la famille GR491 (champ gr491_famille).",
+    "description": "52 règles d'éco-conception couvrant les 9 familles du RGESN 2024 (Référentiel Général d'Écoconception de Services Numériques, 78 critères). Chaque règle référence le ou les critères RGESN correspondants (champ rgesn_ref) et la famille GR491 (champ gr491_famille).",
     "version": "3.0.0",
     "sources": [
       "https://ecoresponsable.numerique.gouv.fr/publications/referentiel-general-ecoconception/",
       "https://gr491.isit-europe.org/",
       "https://greensoftware.foundation/"
     ],
-    "coverage_note": "Le RGESN 2024 compte 78 critères en 9 familles ; le GR491 compte 61 recommandations et 516 critères en 8 familles. Ce fichier sélectionne 44 règles actionnables sans reproduire le référentiel complet : chaque famille RGESN est représentée, et le champ rgesn_ref renvoie au critère officiel pour approfondir. rgesn_ref au format 'N.x' signifie que la règle relève de la famille N sans correspondre à un critère unique.",
-    "count": 44,
+    "coverage_note": "Le RGESN 2024 compte 78 critères en 9 familles ; le GR491 compte 61 recommandations et 516 critères en 8 familles. Ce fichier sélectionne 52 règles actionnables sans reproduire le référentiel complet : chaque famille RGESN est représentée, et le champ rgesn_ref renvoie au critère officiel pour approfondir. rgesn_ref au format 'N.x' signifie que la règle relève de la famille N sans correspondre à un critère unique.",
+    "count": 52,
     "type": "code_audit",
     "type_note": "Les règles avec 'patterns' sont détectées dans le code par l'audit (grep). Les règles avec 'detector' utilisent un détecteur dédié multi-lignes (scripts/detect-*.awk) quand grep ligne-par-ligne ne suffit pas. Celles sans pattern ni detector sont des règles de conception/processus : elles servent de checklist via --list-rules."
   },
@@ -65,6 +65,54 @@
             "formats",
             "ouverture",
             "interoperabilite"
+          ]
+        },
+        {
+          "id": "ECO-STRAT-04",
+          "title": "Désigner un référent sobriété numérique",
+          "description": "Sans personne identifiée pour porter le sujet, la sobriété numérique reste une intention collective que personne ne pousse concrètement au quotidien.",
+          "impact": "Moyen",
+          "patterns": [],
+          "recommendation": "Désigner une personne ou un petit groupe référent, avec le mandat de suivre les objectifs de sobriété et d'arbitrer les compromis.",
+          "rgesn_ref": "1.x",
+          "gr491_famille": "Stratégie",
+          "source_note": "WSG (W3C Web Sustainability Guidelines) — Business Strategy and Product Management > \"Assign a sustainability advocate\".",
+          "tags": [
+            "gouvernance",
+            "organisation",
+            "demarche"
+          ]
+        },
+        {
+          "id": "ECO-STRAT-05",
+          "title": "Former et sensibiliser l'équipe à la sobriété numérique",
+          "description": "Une équipe qui ne connaît pas les enjeux ni les leviers de la sobriété numérique ne peut pas les appliquer, même avec les meilleures règles écrites.",
+          "impact": "Moyen",
+          "patterns": [],
+          "recommendation": "Prévoir une sensibilisation initiale et des points réguliers ; partager les mesures et les progrès pour maintenir l'attention sur le sujet.",
+          "rgesn_ref": "1.x",
+          "gr491_famille": "Stratégie",
+          "source_note": "WSG (W3C Web Sustainability Guidelines) — Business Strategy and Product Management > \"Inform, raise awareness, and train for sustainability\".",
+          "tags": [
+            "formation",
+            "sensibilisation",
+            "demarche"
+          ]
+        },
+        {
+          "id": "ECO-STRAT-06",
+          "title": "Communiquer l'impact environnemental des choix aux utilisateurs",
+          "description": "Un utilisateur qui ne sait pas qu'une action a un coût (lancer une vidéo en haute qualité, télécharger un gros fichier) ne peut pas faire de choix éclairé.",
+          "impact": "Faible",
+          "patterns": [],
+          "recommendation": "Afficher le poids ou la qualité avant une action coûteuse (taille d'un téléchargement, résolution vidéo par défaut) et laisser le choix à l'utilisateur.",
+          "rgesn_ref": "1.x",
+          "gr491_famille": "Stratégie",
+          "source_note": "WSG (W3C Web Sustainability Guidelines) — Business Strategy and Product Management > \"Communicate the environmental impact of user choices\".",
+          "tags": [
+            "transparence",
+            "ux",
+            "demarche"
           ]
         }
       ]
@@ -350,6 +398,24 @@
             "sobriete-editoriale",
             "video"
           ]
+        },
+        {
+          "id": "ECO-UX-07",
+          "title": "Respecter prefers-reduced-motion pour les animations",
+          "description": "Forcer une animation à un visiteur qui a explicitement demandé d'en avoir moins (réglage système, souvent lié à une contrainte matérielle, de confort ou de consommation) gaspille du CPU/GPU pour un rendu que personne ne veut voir.",
+          "impact": "Faible",
+          "patterns": [],
+          "detector": "reduced_motion",
+          "detector_note": "scripts/detect-reduced-motion.awk signale un fichier avec @keyframes ou animation: mais sans aucune media query prefers-reduced-motion nulle part dans le même fichier. Faux négatif possible si la media query vit dans un autre fichier CSS du projet — l'audit ne voit qu'un fichier à la fois.",
+          "recommendation": "Envelopper ou désactiver les animations non essentielles dans @media (prefers-reduced-motion: reduce).",
+          "rgesn_ref": "4.x",
+          "gr491_famille": "UX/UI",
+          "source_note": "WSG (W3C Web Sustainability Guidelines) — UX Design > \"Ensure animation is proportionate and easy to control\" > \"Control animation\".",
+          "tags": [
+            "css",
+            "animation",
+            "accessibilite"
+          ]
         }
       ]
     },
@@ -604,6 +670,24 @@
             "legacy",
             "compatibilite"
           ]
+        },
+        {
+          "id": "ECO-FRONT-13",
+          "title": "Différer le chargement des scripts non critiques",
+          "description": "Un <script src=\"...\"> sans async ni defer bloque le parsing HTML le temps de télécharger et d'exécuter le script, retardant l'affichage de tout ce qui suit dans le document.",
+          "impact": "Moyen",
+          "patterns": [],
+          "detector": "blocking_scripts",
+          "detector_note": "scripts/detect-blocking-scripts.awk reconnaît la balise <script ...> sur une seule ligne (le cas quasi systématique) ; une balise étalée sur plusieurs lignes n'est pas suivie. Les scripts type=\"module\" sont exclus (différés par défaut selon la spécification HTML).",
+          "recommendation": "Ajouter async (script indépendant du DOM et de l'ordre d'exécution) ou defer (script qui doit s'exécuter après le parsing, dans l'ordre) selon le besoin.",
+          "rgesn_ref": "6.x",
+          "gr491_famille": "Front-end",
+          "source_note": "WSG (W3C Web Sustainability Guidelines) — Web Development > \"Defer the loading of non-critical resources\" > \"Asynchronous code\".",
+          "tags": [
+            "javascript",
+            "chargement",
+            "performance"
+          ]
         }
       ]
     },
@@ -617,13 +701,14 @@
           "description": "SELECT *, fonctions dans les WHERE et tris aléatoires font travailler la base bien au-delà du besoin.",
           "impact": "Élevé",
           "patterns": [
-            "SELECT \\*",
-            "WHERE 1=1",
-            "ORDER BY.*RAND\\(\\)"
+            "SELECT\\s+\\*",
+            "WHERE\\s+1\\s*=\\s*1",
+            "ORDER BY.*RAND(OM)?\\(\\)"
           ],
           "recommendation": "Sélectionner uniquement les colonnes nécessaires, indexer les colonnes filtrées, éviter les fonctions dans les clauses WHERE et les requêtes N+1.",
           "rgesn_ref": "7.x",
           "gr491_famille": "Back-end",
+          "detector_note": "Les patterns sont ligne-par-ligne : un SELECT * étalé sur plusieurs lignes (SELECT\\n  *\\nFROM ...) n'est pas détecté, seule la forme sur une ligne l'est.",
           "tags": [
             "sql",
             "performance",
@@ -729,6 +814,65 @@
             "cache",
             "http",
             "performance"
+          ]
+        },
+        {
+          "id": "ECO-HEB-04",
+          "title": "Utiliser HTTPS plutôt que HTTP",
+          "description": "Une requête en clair ne bénéficie pas de la compression et du multiplexage de HTTP/2 (qui exige TLS en pratique dans tous les navigateurs), et expose à une interception qui peut forcer un retéléchargement.",
+          "impact": "Moyen",
+          "patterns": [],
+          "detector": "insecure_links",
+          "detector_note": "scripts/detect-insecure-links.awk exclut ce qui n'est pas une vraie requête réseau : espaces de noms XML/SVG (http://www.w3.org/, http://schema.org/) et localhost/127.0.0.1 (développement local).",
+          "recommendation": "Utiliser https:// systématiquement, y compris pour les ressources tierces et les liens sortants.",
+          "rgesn_ref": "8.x",
+          "gr491_famille": "Hébergement",
+          "tags": [
+            "https",
+            "tls",
+            "securite"
+          ]
+        },
+        {
+          "id": "ECO-HEB-05",
+          "title": "Pas de protocole TLS/SSL obsolète",
+          "description": "SSLv2/v3 et TLS 1.0/1.1 sont dépréciés (vulnérabilités connues) et moins efficaces que TLS 1.2+, qui bénéficie d'un chiffrement plus rapide et de meilleures performances de connexion.",
+          "impact": "Moyen",
+          "patterns": [
+            "TLSv1\\.0",
+            "TLSv1\\.1",
+            "TLSv1_method",
+            "TLSv1_1_method",
+            "SSLv2_method",
+            "SSLv3_method",
+            "SSLv23_method",
+            "TLSv1([^.0-9]|$)"
+          ],
+          "recommendation": "Configurer un minimum TLS 1.2 (idéalement 1.3) côté serveur ou dans les options de connexion sortante.",
+          "rgesn_ref": "8.x",
+          "gr491_famille": "Hébergement",
+          "source_note": "Recoupe YellowLabTools (policies.js : oldTlsProtocol, non repris tel quel car mesuré au runtime par YLT — ici détecté statiquement sur les protocoles explicitement configurés dans le code).",
+          "tags": [
+            "tls",
+            "ssl",
+            "securite"
+          ]
+        },
+        {
+          "id": "ECO-HEB-06",
+          "title": "Pas de liens ou ressources locales cassés",
+          "description": "Un href/src qui pointe vers un fichier du projet qui n'existe pas devient un 404 dès la mise en ligne — un aller-retour réseau et un rendu dégradé pour rien.",
+          "impact": "Faible",
+          "patterns": [],
+          "detector": "broken_links",
+          "detector_note": "scripts/detect-broken-links.awk ne vérifie que les chemins locaux/relatifs résolvables sur disque. Les URLs externes (http/https) ne sont pas vérifiées : un vrai lien externe mort ne peut être détecté qu'en le requêtant réellement, hors de portée d'un audit statique sans réseau (comme notFound de YellowLabTools, mesuré au runtime).",
+          "recommendation": "Corriger le chemin ou retirer la référence si le fichier n'existe plus.",
+          "rgesn_ref": "8.x",
+          "gr491_famille": "Hébergement",
+          "tags": [
+            "liens",
+            "404",
+            "maintenance"
           ]
         }
       ]

--- a/skills/green-claude/scripts/detect-blocking-scripts.awk
+++ b/skills/green-claude/scripts/detect-blocking-scripts.awk
@@ -1,0 +1,26 @@
+# Détecteur de scripts bloquants (ECO-FRONT-13) : un <script src="..."> sans
+# async ni defer arrête le parsing HTML le temps de télécharger et exécuter
+# le script, retardant l'affichage de tout ce qui suit. Les scripts de type
+# "module" sont exclus : ils sont différés par défaut selon la spécification
+# HTML, pas besoin d'async/defer explicite.
+#
+# Heuristique : reconnaît la balise <script ...> sur une seule ligne (le cas
+# quasi systématique en pratique). Une balise <script> étalée sur plusieurs
+# lignes (attributs sur des lignes séparées) n'est pas suivie — limite
+# assumée, un détecteur de candidats, pas une preuve.
+#
+# Sortie : "numéro_de_ligne:ligne" pour chaque script candidat.
+
+{
+    line = $0
+    if (match(line, /<script[^>]*src=[^>]*>/)) {
+        tag = substr(line, RSTART, RLENGTH)
+        # Pas de \b : POSIX ERE (awk) ne le supporte pas, contrairement à
+        # grep/sed. Simple sous-chaîne ici : le risque qu'"async"/"defer"
+        # apparaisse par coïncidence ailleurs dans une balise <script> est
+        # négligeable.
+        if (tag !~ /async/ && tag !~ /defer/ && tag !~ /type=["\047]module["\047]/) {
+            printf "%d:%s\n", NR, line
+        }
+    }
+}

--- a/skills/green-claude/scripts/detect-broken-links.awk
+++ b/skills/green-claude/scripts/detect-broken-links.awk
@@ -1,0 +1,52 @@
+# Détecteur de liens locaux cassés (ECO-HEB-06) : un href/src qui pointe
+# vers un fichier du projet lui-même mais que ce fichier n'existe pas sur
+# disque devient un 404 dès la mise en ligne — un aller-retour réseau et un
+# rendu de page dégradé pour rien.
+#
+# Portée assumée : seuls les chemins locaux/relatifs sont vérifiables sans
+# requête réseau. Les URLs externes (http/https), les ancres (#section) et
+# les liens mailto:/tel: sont ignorés — un vrai lien externe mort ne peut
+# être détecté qu'en le requêtant réellement, hors de portée d'un audit
+# statique sans réseau.
+#
+# Sortie : "numéro_de_ligne:ligne" pour chaque référence locale introuvable.
+
+{
+    # FILENAME n'est pas fiable dans BEGIN (pas encore défini à ce stade en
+    # awk) : le répertoire est calculé ici, au premier enregistrement lu.
+    if (!dir_computed) {
+        dir = FILENAME
+        slash = 0
+        for (i = length(dir); i > 0; i--) {
+            if (substr(dir, i, 1) == "/") { slash = i; break }
+        }
+        dir = (slash > 0) ? substr(dir, 1, slash - 1) : "."
+        dir_computed = 1
+    }
+
+    line = $0
+    rest = line
+    while (match(rest, /(href|src)=["'][^"']+["']/)) {
+        token = substr(rest, RSTART, RLENGTH)
+        rest = substr(rest, RSTART + RLENGTH)
+
+        q = index(token, "\"")
+        if (q == 0) q = index(token, "'")
+        ref = substr(token, q + 1)
+        ref = substr(ref, 1, length(ref) - 1)
+
+        if (ref == "" || ref ~ /^(https?:|mailto:|tel:|#|data:|javascript:|\/\/)/) continue
+
+        sub(/[?#].*$/, "", ref)  # ancre/paramètres : seul le chemin compte
+        if (ref == "") continue
+
+        candidate = (ref ~ /^\//) ? ref : dir "/" ref
+        cmd = "test -e \"" candidate "\" && echo yes || echo no"
+        cmd | getline exists
+        close(cmd)
+
+        if (exists == "no") {
+            printf "%d:%s\n", NR, line
+        }
+    }
+}

--- a/skills/green-claude/scripts/detect-insecure-links.awk
+++ b/skills/green-claude/scripts/detect-insecure-links.awk
@@ -1,0 +1,27 @@
+# Détecteur de liens HTTP non sécurisés (ECO-HEB-04). Une requête en clair
+# ne bénéficie pas de la compression et du multiplexage de HTTP/2 (qui
+# exige TLS en pratique dans tous les navigateurs), et expose à une
+# renégociation ou un homme du milieu qui peut forcer un retéléchargement.
+#
+# Exclut ce qui n'est pas une vraie requête réseau ou un cas de
+# développement légitime : les espaces de noms XML/SVG (http://www.w3.org/,
+# http://schema.org/) sont des identifiants, pas des adresses appelées ; et
+# localhost/127.0.0.1 servent au développement local, où le TLS n'a pas la
+# même pertinence.
+#
+# Sortie : "numéro_de_ligne:ligne" pour chaque URL http:// candidate
+# (une seule fois par ligne, même si elle en contient plusieurs).
+
+{
+    line = $0
+    rest = line
+    while (match(rest, /http:\/\/[^"'"'"' )>]+/)) {
+        url = substr(rest, RSTART, RLENGTH)
+        rest = substr(rest, RSTART + RLENGTH)
+
+        if (url !~ /^http:\/\/(localhost|127\.0\.0\.1|www\.w3\.org|schema\.org)/) {
+            printf "%d:%s\n", NR, line
+            next
+        }
+    }
+}

--- a/skills/green-claude/scripts/detect-reduced-motion.awk
+++ b/skills/green-claude/scripts/detect-reduced-motion.awk
@@ -1,0 +1,28 @@
+# Détecteur d'animations sans respect de prefers-reduced-motion
+# (ECO-FRONT-14). Le WSG (W3C Web Sustainability Guidelines) demande de
+# rendre les animations proportionnées et faciles à contrôler : forcer une
+# animation à un visiteur qui a explicitement demandé d'en avoir moins
+# (réglage système, souvent lié à une contrainte matérielle ou de
+# consommation) gaspille du CPU/GPU pour un rendu que personne ne veut voir.
+#
+# Heuristique sur tout le fichier (pas ligne par ligne) : présence de
+# @keyframes ou d'une déclaration animation: SANS présence, n'importe où
+# dans le même fichier, d'une media query prefers-reduced-motion. Un
+# faux négatif est possible si la media query vit dans un autre fichier CSS
+# du même projet — l'audit ne voit qu'un fichier à la fois.
+#
+# Sortie : un message unique si le fichier a des animations mais aucun
+# prefers-reduced-motion détecté, sinon rien.
+
+BEGIN { has_animation = 0; has_reduced_motion_query = 0 }
+
+{
+    if ($0 ~ /@keyframes/ || $0 ~ /animation[ \t]*:/) has_animation = 1
+    if ($0 ~ /prefers-reduced-motion/) has_reduced_motion_query = 1
+}
+
+END {
+    if (has_animation && !has_reduced_motion_query) {
+        print "animation(s) détectée(s) sans @media (prefers-reduced-motion: reduce) dans ce fichier"
+    }
+}

--- a/skills/green-claude/scripts/test-eco-audit.sh
+++ b/skills/green-claude/scripts/test-eco-audit.sh
@@ -90,8 +90,13 @@ cat > "$TMP/gallery.html" <<EOF
 EOF
 OUT="$(bash eco-audit.sh "$TMP/gallery.html")"
 echo "$OUT" | grep -q '200x100px' || fail "enrichissement image : dimensions réelles non détectées"
-echo "$OUT" | grep -q 'remote.png' && fail "enrichissement image : ne doit rien affirmer sur une URL distante"
-echo "$OUT" | grep -q 'n-existe-pas.png' && fail "enrichissement image : ne doit rien affirmer sur un fichier absent"
+# Le fichier contient aussi un lien mort (n-existe-pas.png) et une image
+# distante, légitimement signalés par ECO-HEB-06 (liens cassés) : on vérifie
+# ici que c'est bien ECO-CONT-01 (enrichissement image) qui ne dit rien sur
+# ces deux-là, pas que la sortie entière les tait (une autre règle le fait).
+CONT01_BLOCK="$(echo "$OUT" | awk '/ECO-CONT-01/{p=1} p&&/^$/{p=0} p')"
+echo "$CONT01_BLOCK" | grep -q 'remote.png' && fail "enrichissement image : ne doit rien affirmer sur une URL distante"
+echo "$CONT01_BLOCK" | grep -q 'n-existe-pas.png' && fail "enrichissement image : ne doit rien affirmer sur un fichier absent"
 true
 
 # 8. ECO-UX-05 (polices) : détection élargie aux CDN tiers, comptage des
@@ -275,4 +280,89 @@ OUT="$(bash eco-audit.sh "$TMP/cleanhack.css")"
 echo "$OUT" | grep -q 'ECO-FRONT-12' && fail "faux positif hack IE sur CSS propre"
 true
 
-echo "OK - 16 verifications passees"
+# 17. ECO-FRONT-13 (script bloquant) : détecte l'absence d'async/defer,
+# silencieux avec async ou type="module".
+cat > "$TMP/blocking.html" <<'EOF'
+<script src="app.js"></script>
+<script src="tracker.js" async></script>
+<script src="mod.js" type="module"></script>
+EOF
+OUT="$(bash eco-audit.sh "$TMP/blocking.html")"
+# Ces 3 fichiers .js n'existent pas non plus sur disque : ECO-HEB-06 (liens
+# cassés) les signale aussi, légitimement, pour une autre raison. On scope
+# la vérification au bloc ECO-FRONT-13 pour ne pas confondre les deux.
+FRONT13_BLOCK="$(echo "$OUT" | awk '/ECO-FRONT-13/{p=1} p&&/^$/{p=0} p')"
+echo "$FRONT13_BLOCK" | grep -q 'app.js' || fail "script bloquant non détecté"
+echo "$FRONT13_BLOCK" | grep -q 'tracker.js' && fail "faux positif : script async signalé comme bloquant"
+echo "$FRONT13_BLOCK" | grep -q 'mod.js' && fail "faux positif : script type=module signalé comme bloquant"
+
+# 18. ECO-UX-07 (prefers-reduced-motion) : détecte une animation sans la
+# media query, silencieux si elle est présente ou s'il n'y a pas d'animation.
+cat > "$TMP/animnoquery.css" <<'EOF'
+.spin { animation: spin 2s linear infinite; }
+EOF
+cat > "$TMP/animwithquery.css" <<'EOF'
+.spin { animation: spin 2s linear infinite; }
+@media (prefers-reduced-motion: reduce) { .spin { animation: none; } }
+EOF
+OUT="$(bash eco-audit.sh "$TMP/animnoquery.css")"
+echo "$OUT" | grep -q 'ECO-UX-07' || fail "animation sans prefers-reduced-motion non détectée"
+OUT="$(bash eco-audit.sh "$TMP/animwithquery.css")"
+echo "$OUT" | grep -q 'ECO-UX-07' && fail "faux positif : prefers-reduced-motion déjà présent"
+true
+
+# 19. ECO-HEB-04 (HTTP non sécurisé) : détecte http://, silencieux sur
+# https://, localhost et les espaces de noms XML (w3.org).
+cat > "$TMP/insecure.js" <<'EOF'
+fetch('http://api.example.com/data');
+EOF
+cat > "$TMP/secure.js" <<'EOF'
+fetch('https://api.example.com/data');
+fetch('http://localhost:3000/api');
+EOF
+cat > "$TMP/svgns.html" <<'EOF'
+<svg xmlns="http://www.w3.org/2000/svg"></svg>
+EOF
+OUT="$(bash eco-audit.sh "$TMP/insecure.js")"
+echo "$OUT" | grep -q 'ECO-HEB-04' || fail "lien http:// non détecté"
+OUT="$(bash eco-audit.sh "$TMP/secure.js")"
+echo "$OUT" | grep -q 'ECO-HEB-04' && fail "faux positif sur https:// ou localhost"
+OUT="$(bash eco-audit.sh "$TMP/svgns.html")"
+echo "$OUT" | grep -q 'ECO-HEB-04' && fail "faux positif sur l'espace de noms SVG w3.org"
+true
+
+# 20. ECO-HEB-05 (TLS/SSL obsolète) : détecte TLSv1/1.1 et les méthodes
+# legacy, silencieux sur TLSv1.2/1.3 (le piège du \b qui matche un préfixe).
+cat > "$TMP/oldtls.js" <<'EOF'
+const o = { secureProtocol: 'TLSv1_method' };
+EOF
+cat > "$TMP/newtls.js" <<'EOF'
+const o = { minVersion: 'TLSv1.2' };
+EOF
+OUT="$(bash eco-audit.sh "$TMP/oldtls.js")"
+echo "$OUT" | grep -q 'ECO-HEB-05' || fail "protocole TLS obsolète non détecté"
+OUT="$(bash eco-audit.sh "$TMP/newtls.js")"
+echo "$OUT" | grep -q 'ECO-HEB-05' && fail "faux positif : TLSv1.2 pris pour TLSv1 obsolète"
+true
+
+# 21. ECO-HEB-06 (liens locaux cassés) : détecte un fichier référencé
+# absent, silencieux sur un fichier présent, une URL externe ou une ancre.
+# Test volontairement lancé alors que le cwd (scripts/) diffère du
+# répertoire du fichier audité ($TMP) : c'est exactement le cas qui avait
+# fait échouer la première version du détecteur (FILENAME non fiable dans
+# BEGIN, "dir" retombait sur "." qui n'était correct que par coïncidence).
+mkdir -p "$TMP/assets"
+echo "ok" > "$TMP/assets/real.css"
+cat > "$TMP/links.html" <<'EOF'
+<link rel="stylesheet" href="assets/real.css">
+<link rel="stylesheet" href="assets/ghost.css">
+<a href="https://example.com/external">externe</a>
+<a href="#section">ancre</a>
+EOF
+OUT="$(bash eco-audit.sh "$TMP/links.html")"
+echo "$OUT" | grep -q 'ghost.css' || fail "lien local cassé non détecté"
+echo "$OUT" | grep -q 'real.css' && fail "faux positif sur un fichier local qui existe bien"
+echo "$OUT" | grep -q 'external' && fail "faux positif sur une URL externe (non vérifiable sans réseau)"
+true
+
+echo "OK - 21 verifications passees"


### PR DESCRIPTION
Trois volets développés et testés ensemble dans la même passe, regroupés en une seule PR plutôt que d'en séparer artificiellement l'historique.

## Corrections `ECO-BACK-01` (SQL), suite à une relecture demandée

- `SELECT   *` (espaces multiples) n'était pas détecté → `SELECT\s+\*`
- `RANDOM()` (PostgreSQL) n'était pas détecté, seul `RAND()` (MySQL) l'était → `RAND(OM)?\(\)`
- `SELECT` étalé sur plusieurs lignes reste non détectable par un pattern grep ligne-par-ligne (même limite que les boucles imbriquées avant leur détecteur dédié) — documenté plutôt que silencieux sans explication.

## 5 règles sourcées du W3C Web Sustainability Guidelines (WSG)

Le WSG n'a pas de numérotation formelle par critère (contrairement au RGESN) : chaque règle cite l'intitulé de section exact.

- `ECO-FRONT-13` : scripts sans `async`/`defer` (Web Development > "Defer the loading of non-critical resources")
- `ECO-UX-07` : animations sans `prefers-reduced-motion` (UX Design > "Ensure animation is proportionate and easy to control")
- `ECO-STRAT-04/05/06` : référent sobriété, formation/sensibilisation, transparence sur l'impact des choix utilisateur (Business Strategy and Product Management)

## 3 règles HTTPS/TLS/liens cassés (famille Hébergement)

- `ECO-HEB-04` : liens `http://` non sécurisés, exclusion des espaces de noms XML/SVG (w3.org, schema.org) et de localhost
- `ECO-HEB-05` : protocoles TLS/SSL obsolètes (minimum TLS 1.2)
- `ECO-HEB-06` : liens/ressources locales cassées — portée limitée aux chemins résolvables sur disque, un vrai lien externe mort nécessite une requête réseau hors de portée d'un audit statique

## Quatre bugs trouvés et corrigés en écrivant/testant ces détecteurs

1. `detect-blocking-scripts.awk` réutilisait `\bpattern\b` comme `detect-duplicate-ids.awk` avant sa correction (`\b` n'existe pas en awk POSIX ERE) — repéré et corrigé avant même de tester.
2. Pattern TLS naïf : `\bTLSv1\b` matche quand même le préfixe de `TLSv1.2`/`TLSv1.3`. `grep -E` n'a pas de lookahead négatif — contourné avec une classe de caractères négative, `TLSv1([^.0-9]|$)`.
3. `detect-broken-links.awk` : `FILENAME` n'est pas fiable dans un bloc `BEGIN` (awk ne le définit qu'à la lecture du premier enregistrement). Le calcul du répertoire du fichier audité retombait toujours sur `.`, correct seulement par coïncidence quand le script tournait depuis ce répertoire — cassait silencieusement dès qu'`eco-audit.sh` l'invoquait d'ailleurs. Déplacé dans le bloc d'action principal.
4. Deux tests existants utilisaient des noms de fichiers factices qui n'existent nulle part ; une fois `ECO-HEB-06` ajouté, il les signale aussi, légitimement, comme liens cassés. Assertions corrigées pour scoper la vérification au bloc de la règle réellement testée.

## Vérifié

`scripts/test-eco-audit.sh` passe à 21/21. 52 règles au total désormais (44 avant ce lot + les 6 YellowLabTools de la PR #17, mergée séparément juste avant celle-ci).