### PR TITLE
Rafraîchit README/page et bump vers 1.3.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "green-claude",
   "description": "Éco-conception de services numériques (RGESN 2024 / GR491 / Green Software Foundation) appliquée pendant que Claude Code écrit ou revoit du code, avec un audit déterministe et des pratiques d'usage sobre inspirées de Boris Cherny. Présentation : https://institut-du-numerique-responsable.github.io/green-claude/",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "author": {
     "name": "Institut du Numérique Responsable"
   },

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ développement ici : [regles-ecoconception-ia](https://github.com/Institut-du-Nu
 
 ## En une phrase
 
-Tu installes le skill une fois. Ensuite, quand Claude Code écrit ou revoit du code dans tes projets, il applique de lui-même les règles d'éco-conception (**RGESN 2024**, **GR491**, **Green Software Foundation**), sans que tu aies à le lui demander à chaque fois.
+Tu installes le skill une fois. Ensuite, quand Claude Code écrit ou revoit du code dans tes projets, il applique de lui-même les règles d'éco-conception (**RGESN 2024**, **GR491**, **Green Software Foundation**, **W3C Web Sustainability Guidelines**, plus des seuils repris de **YellowLabTools**), sans que tu aies à le lui demander à chaque fois.
 
 ## Pourquoi un skill plutôt qu'une simple liste de règles
 
@@ -147,6 +147,8 @@ Ajoute un fichier JSON dans `skills/green-claude/rules/`, structuré comme `ecoc
 - `patterns` : expressions régulières `grep -E` détectant le problème. **Liste vide = pratique** (checklist, ignorée par l'audit).
 - `impact` : `Élevé`, `Moyen` ou `Faible`.
 - `rgesn_ref` / `gr491_famille` (optionnels) : renvoi vers les référentiels officiels.
+- `detector` / `enrich` (optionnels) : pour les cas qu'un pattern seul ne peut pas voir (imbrication multi-lignes, comptage, poids réel d'un fichier référencé...), un script dédié dans `scripts/`. Détail complet dans [CONTRIBUTING.md](CONTRIBUTING.md).
+- `note` (optionnel) : mise en garde affichée dans le résultat de l'audit (faux positif connu, seuil, portée limitée) — l'endroit où documenter les pièges d'interprétation d'une règle, pas dans le skill lui-même.
 
 Relance ensuite `./install.sh` pour republier le skill mis à jour.
 
@@ -159,7 +161,7 @@ Relance ensuite `./install.sh` pour republier le skill mis à jour.
 3. Ajoutez vos règles ou améliorations (`jq empty skills/green-claude/rules/*.json` pour valider le JSON)
 4. Ouvrez une **Pull Request**
 
-Les contributions les plus utiles : nouvelles règles d'audit sourcées (RGESN, GR491, GSF) avec leur `rgesn_ref`, corrections de patterns (faux positifs), traductions.
+Les contributions les plus utiles : nouvelles règles d'audit sourcées (RGESN, GR491, GSF, WSG, ou une autre référence publique reconnue) avec leur `rgesn_ref`, corrections de patterns (faux positifs), traductions.
 
 Détail complet du format des règles et du processus de PR : [CONTRIBUTING.md](CONTRIBUTING.md).
 
@@ -170,6 +172,8 @@ Détail complet du format des règles et du processus de PR : [CONTRIBUTING.md](
 - [RGESN 2024](https://ecoresponsable.numerique.gouv.fr/publications/referentiel-general-ecoconception/) : Référentiel Général d'Écoconception de Services Numériques (78 critères, 9 familles)
 - [GR491](https://gr491.isit-europe.org/) : Guide de référence de conception responsable de services numériques (61 recommandations, 516 critères)
 - [Green Software Foundation](https://greensoftware.foundation/) : patterns d'éco-conception logicielle
+- [W3C Web Sustainability Guidelines](https://w3c.github.io/sustainableweb-wsg/) : recommandations de durabilité web (UX, développement, hébergement, stratégie)
+- [YellowLabTools](https://github.com/YellowLabTools/YellowLabTools) : outil open source d'audit de qualité front-end, source de plusieurs seuils (DOM, CSS, polices)
 - [How Boris uses Claude Code](https://howborisusesclaudecode.com/) : les pratiques de Boris Cherny, créateur de Claude Code
 - [Anthropic](https://www.anthropic.com/) : Claude et Claude Code
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,12 +4,12 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Green Claude : sobriété numérique pour Claude Code | Éco-conception IA</title>
-  <meta name="description" content="Green Claude : skill open source pour Claude Code qui guide Claude vers un code éco-conçu, automatiquement, selon les référentiels RGESN 2024, GR491 et Green Software Foundation.">
+  <meta name="description" content="Green Claude : skill open source pour Claude Code qui guide Claude vers un code éco-conçu, automatiquement, selon les référentiels RGESN 2024, GR491, Green Software Foundation et W3C Web Sustainability Guidelines.">
   <meta name="author" content="Institut du Numérique Responsable">
   <meta name="robots" content="index, follow">
   <link rel="canonical" href="https://institut-du-numerique-responsable.github.io/green-claude/">
   <meta property="og:title" content="Green Claude : sobriété numérique pour Claude Code">
-  <meta property="og:description" content="Skill open source pour Claude Code : code éco-conçu par défaut (RGESN 2024 / GR491), plus un hook optionnel de cache local et heures creuses.">
+  <meta property="og:description" content="Skill open source pour Claude Code : code éco-conçu par défaut (RGESN 2024 / GR491 / WSG), plus un hook optionnel de cache local et heures creuses.">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://institut-du-numerique-responsable.github.io/green-claude/">
   <meta property="og:locale" content="fr_FR">
@@ -20,7 +20,7 @@
   <meta property="og:image:alt" content="Green Claude : un prompt de terminal dont le curseur devient une pousse verte">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Green Claude : sobriété numérique pour Claude Code">
-  <meta name="twitter:description" content="Skill open source pour un agent IA de code éco-conçu par défaut (RGESN 2024 / GR491), plus un hook optionnel de cache local et heures creuses.">
+  <meta name="twitter:description" content="Skill open source pour un agent IA de code éco-conçu par défaut (RGESN 2024 / GR491 / WSG), plus un hook optionnel de cache local et heures creuses.">
   <meta name="twitter:image" content="https://institut-du-numerique-responsable.github.io/green-claude/assets/logo.jpg">
   <meta name="twitter:image:alt" content="Green Claude : un prompt de terminal dont le curseur devient une pousse verte">
   <link rel="icon" type="image/jpeg" href="assets/logo.jpg">
@@ -31,8 +31,8 @@
     "name": "Green Claude",
     "applicationCategory": "DeveloperApplication",
     "operatingSystem": "macOS, Linux",
-    "softwareVersion": "1.2.1",
-    "description": "Skill pour Claude Code : sobriété numérique du code produit (RGESN 2024, GR491, Green Software Foundation), installé une fois et appliqué automatiquement.",
+    "softwareVersion": "1.3.0",
+    "description": "Skill pour Claude Code : sobriété numérique du code produit (RGESN 2024, GR491, Green Software Foundation, W3C Web Sustainability Guidelines), installé une fois et appliqué automatiquement.",
     "license": "https://opensource.org/licenses/MIT",
     "url": "https://github.com/Institut-du-Numerique-Responsable/green-claude",
     "codeRepository": "https://github.com/Institut-du-Numerique-Responsable/green-claude",
@@ -140,7 +140,7 @@ cd green-claude && ./install.sh</code></pre>
   <h2>Ce que contient le projet</h2>
   <ul>
     <li>Un skill Claude Code qui s'invoque tout seul dès qu'il s'agit d'écrire ou de revoir du code.</li>
-    <li>52 règles d'éco-conception couvrant les 9 familles du <a href="https://ecoresponsable.numerique.gouv.fr/publications/referentiel-general-ecoconception/">RGESN 2024</a>, dont l'Algorithmie et l'IA frugale, reliées au <a href="https://gr491.isit-europe.org/">GR491</a>.</li>
+    <li>52 règles d'éco-conception couvrant les 9 familles du <a href="https://ecoresponsable.numerique.gouv.fr/publications/referentiel-general-ecoconception/">RGESN 2024</a>, dont l'Algorithmie et l'IA frugale, reliées au <a href="https://gr491.isit-europe.org/">GR491</a>, avec des règles complémentaires sourcées du <a href="https://w3c.github.io/sustainableweb-wsg/">W3C Web Sustainability Guidelines</a> et des seuils repris de <a href="https://github.com/YellowLabTools/YellowLabTools">YellowLabTools</a>.</li>
     <li>14 pratiques de sobriété inspirées de Boris Cherny, le créateur de Claude Code : chacune est sourcée et expliquée.</li>
     <li>Un hook optionnel pour le cache local des réponses et un avertissement aux heures de pointe, proposé à l'installation, jamais imposé.</li>
   </ul>

--- a/skills/green-claude/SKILL.md
+++ b/skills/green-claude/SKILL.md
@@ -8,7 +8,7 @@ description: |
   "RGESN", "GR491", "écoconception", "green IT"), ou quand invoqué via
   /green-claude pour parcourir la checklist des règles.
 author: Institut du Numérique Responsable
-version: 1.2.1
+version: 1.3.0
 license: MIT
 user-invocable: true
 ---


### PR DESCRIPTION
## Le problème

Le README et la page de présentation citaient encore uniquement RGESN/GR491/GSF comme sources, alors que le W3C Web Sustainability Guidelines et YellowLabTools sont devenus des sources significatives (14 des 52 règles) sans jamais être mentionnés ni référencés.

## Ce qui change

- **README** : mention WSG/YellowLabTools dans « En une phrase », la liste des sources acceptées pour contribuer, et une entrée dédiée dans Références. La section « Écrire ses propres règles » ne mentionnait ni `detector`, ni `enrich`, ni `note` — trois mécanismes désormais centraux (14+ règles les utilisent) — ajout d'un pointeur vers `CONTRIBUTING.md` pour le détail.
- **docs/index.html** : mêmes ajouts dans les meta description/og/twitter et le corps de page.
- **Version** 1.2.1 → 1.3.0 (`plugin.json`, `SKILL.md`, JSON-LD de la page) : 38 → 52 règles, nouveau mécanisme de `note` affichée dans l'audit, 7 nouveaux détecteurs awk — justifient un bump au-delà d'un simple patch.

## Vérifié

`claude plugin validate`, `scripts/test-eco-audit.sh` (21/21), `hooks/test-cache.sh` (7/7), versions cohérentes partout.