### PR TITLE
Corrige la longueur du title/description et la date du sitemap

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Green Claude : sobriété numérique pour Claude Code | Éco-conception IA</title>
-  <meta name="description" content="Green Claude : skill open source pour Claude Code qui guide Claude vers un code éco-conçu, automatiquement, selon les référentiels RGESN 2024, GR491, Green Software Foundation et W3C Web Sustainability Guidelines.">
+  <title>Green Claude : sobriété numérique pour Claude Code</title>
+  <meta name="description" content="Green Claude : skill open source pour Claude Code, code éco-conçu selon le RGESN 2024, le GR491 et d'autres référentiels reconnus.">
   <meta name="author" content="Institut du Numérique Responsable">
   <meta name="robots" content="index, follow">
   <link rel="canonical" href="https://institut-du-numerique-responsable.github.io/green-claude/">

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://institut-du-numerique-responsable.github.io/green-claude/</loc>
-    <lastmod>2026-07-21</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>1.0</priority>
   </url>


### PR DESCRIPTION
## Le problème

Le title (70 caractères) et surtout la meta description (213 caractères après le dernier ajout des sources WSG/YellowLabTools) dépassaient largement les longueurs recommandées pour un bon rendu dans les résultats de recherche (title ~50-60, description ~150-160) — Google tronque au-delà, généralement en plein milieu d'un mot.

## Ce qui change

- **title** : retrait du suffixe « | Éco-conception IA » (70 → 50 caractères), le nom du projet et le sujet restent clairs sans lui.
- **description** : reformulée pour rester sous 130 caractères sans perdre l'information utile (RGESN, GR491, « autres référentiels reconnus » plutôt que d'énumérer les 5 sources en toutes lettres).
- **sitemap.xml** : `lastmod` était resté figé au 21/07 malgré plusieurs mises à jour de la page depuis — remis à la date du jour.

## Vérifié

Dogfooding : audit de `docs/index.html` avec notre propre outil. Deux hits (`ECO-UX-01` « autoplay », `ECO-BACK-01` « SELECT * ») viennent tous les deux de la même ligne de prose qui décrit l'outil en citant ces motifs comme exemples — pas du code réel. Confirme que le principe « candidat, pas preuve » déjà documenté dans `SKILL.md` fonctionne comme prévu, rien à changer dans les règles.