### PR TITLE
Ajoute un exemple concret au README et à la page, humanise un titre

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,34 @@ Rien à taper. Trois façons de s'en servir :
 
 L'audit (`skills/green-claude/scripts/eco-audit.sh`) est un script déterministe (grep sur les règles) : il ne coûte pas de raisonnement au modèle, juste la lecture du résultat.
 
+## Exemple concret
+
+Ce code, tout à fait banal :
+
+```js
+import _ from 'lodash';
+
+app.get('/api/users', (req, res) => {
+  db.query('SELECT * FROM users', (err, rows) => {
+    res.json(rows);
+  });
+});
+```
+
+`eco-audit.sh api.js` (sortie réelle, non retouchée) :
+
+```
+[Élevé] ECO-FRONT-01 — Pas de bibliothèque lourde pour un besoin mineur
+  Recommandation : Préférer les fonctions natives du langage ou des alternatives légères (date-fns, Alpine.js).
+
+[Élevé] ECO-BACK-01 — Optimiser les requêtes SQL
+  Recommandation : Sélectionner uniquement les colonnes nécessaires, indexer les colonnes filtrées, éviter les fonctions dans les clauses WHERE et les requêtes N+1.
+
+2 issue(s) d'éco-conception détectée(s).
+```
+
+En pratique, tu n'as pas besoin de lancer l'audit toi-même sur ce genre de code : en mode proactif, Claude évite `lodash` pour une seule fonction et `SELECT *` dès l'écriture, avant même qu'un audit ait lieu.
+
 ---
 
 ## Les règles : 52 règles alignées sur les 9 familles du RGESN 2024

--- a/docs/index.html
+++ b/docs/index.html
@@ -117,7 +117,7 @@
     <a class="cta secondary" href="https://github.com/Institut-du-Numerique-Responsable/green-claude#installation">Installer</a>
   </p>
 
-  <h2>Ce que le skill fait pour toi</h2>
+  <h2>Comment ça marche</h2>
   <div class="duo">
     <div class="card">
       <h3>Pendant que Claude code</h3>
@@ -128,6 +128,25 @@
       <p>« Audit éco-conception de ce fichier » lance un script déterministe (grep sur les règles), zéro coût de raisonnement, qui détecte les motifs contraires à l'éco-conception (SELECT *, bibliothèques lourdes, autoplay…).</p>
     </div>
   </div>
+
+  <h2>Exemple concret</h2>
+  <p>Ce code, tout à fait banal :</p>
+  <pre><code>import _ from 'lodash';
+
+app.get('/api/users', (req, res) => {
+  db.query('SELECT * FROM users', (err, rows) => {
+    res.json(rows);
+  });
+});</code></pre>
+  <p><code>eco-audit.sh api.js</code> (sortie réelle, non retouchée) :</p>
+  <pre><code>[Élevé] ECO-FRONT-01 — Pas de bibliothèque lourde pour un besoin mineur
+  Recommandation : Préférer les fonctions natives du langage ou des alternatives légères (date-fns, Alpine.js).
+
+[Élevé] ECO-BACK-01 — Optimiser les requêtes SQL
+  Recommandation : Sélectionner uniquement les colonnes nécessaires, indexer les colonnes filtrées, éviter les fonctions dans les clauses WHERE et les requêtes N+1.
+
+2 issue(s) d'éco-conception détectée(s).</code></pre>
+  <p>En pratique, pas besoin de lancer l'audit toi-même sur ce genre de code : en mode proactif, Claude évite <code>lodash</code> pour une seule fonction et <code>SELECT *</code> dès l'écriture, avant même qu'un audit ait lieu.</p>
 
   <h2>En 30 secondes</h2>
   <pre><code>/plugin marketplace add Institut-du-Numerique-Responsable/green-claude


### PR DESCRIPTION
Le projet décrivait ce que fait l'audit sans jamais montrer sa sortie réelle — souvent ce qui convainc le plus vite un visiteur. Ajout d'un exemple (sortie non retouchée, obtenue en faisant réellement tourner `eco-audit.sh` sur un extrait de code) dans les deux surfaces : README et `docs/index.html`.

Au passage, « Ce que le skill fait pour toi » renommé « Comment ça marche » dans la page — plus direct, moins générique.

Vérifié : balises HTML équilibrées, poids de page toujours raisonnable (11,8 Ko / 4,5 Ko gzip), `scripts/test-eco-audit.sh` 21/21.