### PR TITLE
Traduit le README en anglais, la page reste en français

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -1,0 +1,212 @@
+# Green Claude : sobriété numérique pour Claude Code
+
+🇬🇧 [Read in English](README.md)
+
+[![Licence MIT](https://img.shields.io/badge/licence-MIT-green.svg)](LICENSE)
+[![RGESN 2024](https://img.shields.io/badge/RGESN-2024-1b7a4a.svg)](https://ecoresponsable.numerique.gouv.fr/publications/referentiel-general-ecoconception/)
+[![GR491](https://img.shields.io/badge/GR491-r%C3%A9f%C3%A9rentiel-1b7a4a.svg)](https://gr491.isit-europe.org/)
+[![Release](https://img.shields.io/github/v/release/Institut-du-Numerique-Responsable/green-claude)](https://github.com/Institut-du-Numerique-Responsable/green-claude/releases)
+[![Site](https://img.shields.io/badge/site-green--claude-blue)](https://institut-du-numerique-responsable.github.io/green-claude/)
+[![Dernier commit](https://img.shields.io/github/last-commit/Institut-du-Numerique-Responsable/green-claude)](https://github.com/Institut-du-Numerique-Responsable/green-claude/commits/main)
+[![Stars GitHub](https://img.shields.io/github/stars/Institut-du-Numerique-Responsable/green-claude?style=flat)](https://github.com/Institut-du-Numerique-Responsable/green-claude/stargazers)
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
+
+**Green Claude** est un skill pour [Claude Code](https://claude.com/claude-code) qui guide Claude vers un code éco-conçu, de façon automatique, sans commande à retenir.
+
+Une production de l'[Institut du Numérique Responsable](https://institutnr.org), 2026, sous licence MIT.
+
+> Un code éco-conçu = moins de ressources consommées chez chaque utilisateur, à chaque exécution, pendant toute la vie du logiciel.
+
+Ce dépôt est spécifique à Claude Code. Une version indépendante des règles,
+portable vers d'autres assistants IA et d'autres langages, est en cours de
+développement ici : [regles-ecoconception-ia](https://github.com/Institut-du-Numerique-Responsable/regles-ecoconception-ia).
+
+---
+
+## En une phrase
+
+Tu installes le skill une fois. Ensuite, quand Claude Code écrit ou revoit du code dans tes projets, il applique de lui-même les règles d'éco-conception (**RGESN 2024**, **GR491**, **Green Software Foundation**, **W3C Web Sustainability Guidelines**, plus des seuils repris de **YellowLabTools**), sans que tu aies à le lui demander à chaque fois.
+
+## Pourquoi un skill plutôt qu'une simple liste de règles
+
+Une checklist RGESN en PDF ou en wiki dépend de la mémoire de qui l'a lue une fois. Personne ne la rouvre avant chaque ligne de code, et son application varie d'une personne à l'autre selon qui s'en souvient ce jour-là.
+
+Un skill Claude Code apporte trois différences concrètes :
+
+- **Chargement automatique à chaque session.** Le skill se charge tout seul, sans qu'on ait à le mentionner en tête de conversation.
+- **Sélection contextuelle des règles.** Claude applique les familles pertinentes pour ce qu'il écrit à l'instant : un backend déclenche les règles SQL et pools de connexions, pas les règles UX/UI sur l'autoplay.
+- **Vérification a posteriori intégrée.** Le script d'audit (`eco-audit.sh`) tourne à la demande sur le code déjà écrit, sans coût de raisonnement pour le modèle, pour attraper ce que l'application proactive a raté.
+
+La checklist reste un document qu'on consulte. Le skill s'exécute au moment où le code s'écrit, dans la session de travail elle-même.
+
+## Installation
+
+### Via le gestionnaire de plugins de Claude Code (recommandé)
+
+```
+/plugin marketplace add Institut-du-Numerique-Responsable/green-claude
+/plugin install green-claude@green-claude
+```
+
+Claude Code gère alors les mises à jour (`/plugin update green-claude`) sans repasser par un `git pull` manuel.
+
+### Via install.sh
+
+```bash
+git clone https://github.com/Institut-du-Numerique-Responsable/green-claude.git
+cd green-claude
+./install.sh
+```
+
+Ça installe le skill dans `~/.claude/skills/green-claude`. Rien d'autre à faire : Claude Code le charge automatiquement dans tes sessions suivantes. Cette méthode reste utile pour câbler en plus les hooks de cache (voir plus bas), que le gestionnaire de plugins ne pose pas automatiquement.
+
+Prérequis : `jq`, pour le script d'audit et les hooks (`brew install jq` / `sudo apt install jq`).
+
+## Utilisation
+
+Rien à taper. Trois façons de s'en servir :
+
+| Tu veux... | Ce que tu fais |
+|---|---|
+| Que Claude code sobrement par défaut | Rien : c'est automatique dès que le skill est installé |
+| Auditer un fichier existant | Demande simplement : *« audit éco-conception de ce fichier »* |
+| Voir la checklist complète | Tape `/green-claude` |
+
+L'audit (`skills/green-claude/scripts/eco-audit.sh`) est un script déterministe (grep sur les règles) : il ne coûte pas de raisonnement au modèle, juste la lecture du résultat.
+
+## Exemple concret
+
+Ce code, tout à fait banal :
+
+```js
+import _ from 'lodash';
+
+app.get('/api/users', (req, res) => {
+  db.query('SELECT * FROM users', (err, rows) => {
+    res.json(rows);
+  });
+});
+```
+
+`eco-audit.sh api.js` (sortie réelle, non retouchée) :
+
+```
+[Élevé] ECO-FRONT-01 — Pas de bibliothèque lourde pour un besoin mineur
+  Recommandation : Préférer les fonctions natives du langage ou des alternatives légères (date-fns, Alpine.js).
+
+[Élevé] ECO-BACK-01 — Optimiser les requêtes SQL
+  Recommandation : Sélectionner uniquement les colonnes nécessaires, indexer les colonnes filtrées, éviter les fonctions dans les clauses WHERE et les requêtes N+1.
+
+2 issue(s) d'éco-conception détectée(s).
+```
+
+En pratique, tu n'as pas besoin de lancer l'audit toi-même sur ce genre de code : en mode proactif, Claude évite `lodash` pour une seule fonction et `SELECT *` dès l'écriture, avant même qu'un audit ait lieu.
+
+---
+
+## Les règles : 52 règles alignées sur les 9 familles du RGESN 2024
+
+[`skills/green-claude/rules/ecoconception.json`](skills/green-claude/rules/ecoconception.json) couvre les **9 familles** du [RGESN 2024](https://www.arcep.fr/mes-demarches-et-services/entreprises/fiches-pratiques/referentiel-general-ecoconception-services-numeriques.html) (78 critères officiels). Chaque règle référence le critère RGESN correspondant (`rgesn_ref`) et la famille [GR491](https://gr491.isit-europe.org/) (`gr491_famille`) :
+
+| Famille RGESN | Règles | Exemples |
+|---|---|---|
+| 1. Stratégie | 6 | Mesurer avant d'optimiser, données raisonnées, formats ouverts, référent sobriété, sensibilisation, transparence utilisateur |
+| 2. Spécifications | 5 | Compatibilité anciens terminaux, bas débit, impact des services tiers |
+| 3. Architecture | 5 | Low-tech d'abord, ressources adaptées à la charge, environnements de test sobres, code testé et maintenable |
+| 4. UX/UI | 7 | Pas d'autoplay ni de scroll infini, composants natifs, polices limitées, média le plus sobre, prefers-reduced-motion |
+| 5. Contenus | 2 | Images optimisées, SVG |
+| 6. Frontend | 13 | Pas de bibliothèque lourde, lazy loading, minification, dépendances, pas de code mort, pas de globales implicites, pas de XHR synchrone, DOM sobre, pas d'IDs dupliqués, !important limité, pas de CSS dupliqué, pas de hacks IE legacy, scripts différés |
+| 7. Backend | 4 | SQL optimisé, pools de connexions, complexité, pagination + cache |
+| 8. Hébergement | 6 | Hébergeur sobre, compression HTTP, cache HTTP, HTTPS/TLS, liens cassés |
+| 9. **Algorithmie (dont IA)** | 4 | **Justifier l'IA, dimensionner le modèle, mesurer, alternatives sobres** |
+
+Les règles sans motif détectable (démarche, gouvernance) sont ignorées par l'audit et servent de checklist dans `/green-claude`.
+
+---
+
+## Les pratiques Boris : utiliser Claude sobrement et avec bon sens
+
+Coder avec l'IA a aussi un coût pendant la session elle-même : chaque requête consomme de l'énergie. [Boris Cherny](https://howborisusesclaudecode.com/), créateur de Claude Code, documente des pratiques d'usage efficace. Un usage efficace est aussi un usage sobre : chaque aller-retour évité économise des tokens, chaque contexte allégé aussi.
+
+[`skills/green-claude/rules/boris.json`](skills/green-claude/rules/boris.json) en reprend 14, dont deux ajoutées avec des exemples d'outils open source vérifiés :
+
+| Pratique | Le geste |
+|---|---|
+| Minimalisme de contexte | Prompt minimal, laisser Claude aller chercher le contexte lui-même |
+| Rembobiner plutôt que corriger | `/rewind` (double Échap) au lieu d'empiler des corrections dans le contexte |
+| `/clear` vs `/compact` | Nouvelle tâche → `/clear`. Tâche liée → `/compact <consigne>` |
+| Cartographier le code | Un index du dépôt (CODEMAP.md, ou un outil comme [graphify](https://github.com/Graphify-Labs/graphify)) évite de relire les mêmes fichiers en entier à chaque session |
+| Réponses denses | Aller droit au résultat plutôt que reformuler (l'esprit derrière des outils comme [caveman](https://github.com/juliusbrussee/caveman)) |
+| Écrire la règle, pas re-corriger | « Ajoute ça à CLAUDE.md » répare une fois pour toutes |
+| Une skill pour ce qui se répète | Un workflow quotidien devient une slash command |
+| Donner un moyen de vérifier | Tests, commande, navigateur : moins de cycles de correction |
+| Adapter le niveau d'effort | `/effort low/high/max` selon la tâche, jamais par défaut au maximum |
+| `--bare` pour les scripts | Démarrage sans contexte projet, pour l'automatisation |
+
+Détail complet : [`skills/green-claude/rules/boris.json`](skills/green-claude/rules/boris.json).
+
+> Les outils tiers cités (graphify, caveman) sont des exemples illustratifs vérifiés (open source, licence MIT). Le projet ne les audite pas et n'en dépend pas.
+
+---
+
+## Ce qu'un skill ne peut pas faire (et comment on le couvre quand même)
+
+Un skill s'exécute *pendant* une session déjà lancée. Il ne peut donc pas décider avec quel modèle démarrer, ni empêcher un appel au modèle avant qu'il n'ait lieu. Deux leviers restent donc hors du skill, dans [`hooks/`](hooks/), optionnels et proposés à l'installation :
+
+- **Cache local** (`hooks/green-claude-cache.sh`) : une question déjà posée est resservie sans réappeler le modèle, zéro token consommé.
+- **Avertissement heures creuses** (même hook) : signale les heures de pointe (hors 22h-6h UTC) sans bloquer.
+
+Ces hooks se câblent dans `~/.claude/settings.json`. Si on réponds « o », `install.sh` les y ajoute (les autres réglages sont préservés et une sauvegarde du fichier d'origine est laissée en `settings.json.green-claude.bak`). Sans `jq` il affiche la config à coller à la main. Pour les retirer : supprimer les deux entrées `green-claude-*` du fichier.
+
+---
+
+## Écrire ses propres règles
+
+Ajoute un fichier JSON dans `skills/green-claude/rules/`, structuré comme `ecoconception.json` (catégories → règles) :
+
+```json
+{
+  "id": "CUSTOM-001",
+  "title": "Ma règle",
+  "impact": "Élevé",
+  "patterns": ["mon_motif_regex"],
+  "recommendation": "Quoi faire à la place."
+}
+```
+
+- `patterns` : expressions régulières `grep -E` détectant le problème. **Liste vide = pratique** (checklist, ignorée par l'audit).
+- `impact` : `Élevé`, `Moyen` ou `Faible`.
+- `rgesn_ref` / `gr491_famille` (optionnels) : renvoi vers les référentiels officiels.
+- `detector` / `enrich` (optionnels) : pour les cas qu'un pattern seul ne peut pas voir (imbrication multi-lignes, comptage, poids réel d'un fichier référencé...), un script dédié dans `scripts/`. Détail complet dans [CONTRIBUTING.md](CONTRIBUTING.md).
+- `note` (optionnel) : mise en garde affichée dans le résultat de l'audit (faux positif connu, seuil, portée limitée) — l'endroit où documenter les pièges d'interprétation d'une règle, pas dans le skill lui-même.
+
+Relance ensuite `./install.sh` pour republier le skill mis à jour.
+
+---
+
+## 🤝 Contribuer
+
+1. **Fork** ce dépôt
+2. Créez une branche (`git checkout -b feature/ma-regle`)
+3. Ajoutez vos règles ou améliorations (`jq empty skills/green-claude/rules/*.json` pour valider le JSON)
+4. Ouvrez une **Pull Request**
+
+Les contributions les plus utiles : nouvelles règles d'audit sourcées (RGESN, GR491, GSF, WSG, ou une autre référence publique reconnue) avec leur `rgesn_ref`, corrections de patterns (faux positifs), traductions.
+
+Détail complet du format des règles et du processus de PR : [CONTRIBUTING.md](CONTRIBUTING.md).
+
+---
+
+## 🙏 Références
+
+- [RGESN 2024](https://ecoresponsable.numerique.gouv.fr/publications/referentiel-general-ecoconception/) : Référentiel Général d'Écoconception de Services Numériques (78 critères, 9 familles)
+- [GR491](https://gr491.isit-europe.org/) : Guide de référence de conception responsable de services numériques (61 recommandations, 516 critères)
+- [Green Software Foundation](https://greensoftware.foundation/) : patterns d'éco-conception logicielle
+- [W3C Web Sustainability Guidelines](https://w3c.github.io/sustainableweb-wsg/) : recommandations de durabilité web (UX, développement, hébergement, stratégie)
+- [YellowLabTools](https://github.com/YellowLabTools/YellowLabTools) : outil open source d'audit de qualité front-end, source de plusieurs seuils (DOM, CSS, polices)
+- [How Boris uses Claude Code](https://howborisusesclaudecode.com/) : les pratiques de Boris Cherny, créateur de Claude Code
+- [Anthropic](https://www.anthropic.com/) : Claude et Claude Code
+
+## 📄 Licence
+
+[MIT](LICENSE), © 2026 Institut du Numérique Responsable

--- a/README.md
+++ b/README.md
@@ -1,52 +1,52 @@
-# Green Claude : sobriété numérique pour Claude Code
+# Green Claude: digital sobriety for Claude Code
 
-[![Licence MIT](https://img.shields.io/badge/licence-MIT-green.svg)](LICENSE)
+🇫🇷 [Lire en français](README.fr.md)
+
+[![MIT License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![RGESN 2024](https://img.shields.io/badge/RGESN-2024-1b7a4a.svg)](https://ecoresponsable.numerique.gouv.fr/publications/referentiel-general-ecoconception/)
-[![GR491](https://img.shields.io/badge/GR491-r%C3%A9f%C3%A9rentiel-1b7a4a.svg)](https://gr491.isit-europe.org/)
+[![GR491](https://img.shields.io/badge/GR491-reference-1b7a4a.svg)](https://gr491.isit-europe.org/)
 [![Release](https://img.shields.io/github/v/release/Institut-du-Numerique-Responsable/green-claude)](https://github.com/Institut-du-Numerique-Responsable/green-claude/releases)
 [![Site](https://img.shields.io/badge/site-green--claude-blue)](https://institut-du-numerique-responsable.github.io/green-claude/)
-[![Dernier commit](https://img.shields.io/github/last-commit/Institut-du-Numerique-Responsable/green-claude)](https://github.com/Institut-du-Numerique-Responsable/green-claude/commits/main)
-[![Stars GitHub](https://img.shields.io/github/stars/Institut-du-Numerique-Responsable/green-claude?style=flat)](https://github.com/Institut-du-Numerique-Responsable/green-claude/stargazers)
+[![Last commit](https://img.shields.io/github/last-commit/Institut-du-Numerique-Responsable/green-claude)](https://github.com/Institut-du-Numerique-Responsable/green-claude/commits/main)
+[![GitHub Stars](https://img.shields.io/github/stars/Institut-du-Numerique-Responsable/green-claude?style=flat)](https://github.com/Institut-du-Numerique-Responsable/green-claude/stargazers)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
 
-**Green Claude** est un skill pour [Claude Code](https://claude.com/claude-code) qui guide Claude vers un code éco-conçu, de façon automatique, sans commande à retenir.
+**Green Claude** is a skill for [Claude Code](https://claude.com/claude-code) that guides Claude toward eco-designed code, automatically, with no command to remember.
 
-Une production de l'[Institut du Numérique Responsable](https://institutnr.org), 2026, sous licence MIT.
+Built by the [Institut du Numérique Responsable](https://institutnr.org) (French non-profit on responsible digital practices), 2026, MIT licensed.
 
-> Un code éco-conçu = moins de ressources consommées chez chaque utilisateur, à chaque exécution, pendant toute la vie du logiciel.
+> Eco-designed code = fewer resources consumed by every user, on every run, for the software's entire lifetime.
 
-Ce dépôt est spécifique à Claude Code. Une version indépendante des règles,
-portable vers d'autres assistants IA et d'autres langages, est en cours de
-développement ici : [regles-ecoconception-ia](https://github.com/Institut-du-Numerique-Responsable/regles-ecoconception-ia).
+This repository is specific to Claude Code. A standalone, portable version of the rules — usable with other AI assistants and other languages — is in development here: [regles-ecoconception-ia](https://github.com/Institut-du-Numerique-Responsable/regles-ecoconception-ia).
 
 ---
 
-## En une phrase
+## In one sentence
 
-Tu installes le skill une fois. Ensuite, quand Claude Code écrit ou revoit du code dans tes projets, il applique de lui-même les règles d'éco-conception (**RGESN 2024**, **GR491**, **Green Software Foundation**, **W3C Web Sustainability Guidelines**, plus des seuils repris de **YellowLabTools**), sans que tu aies à le lui demander à chaque fois.
+Install the skill once. From then on, whenever Claude Code writes or reviews code in your projects, it applies eco-design rules on its own (**RGESN 2024**, **GR491**, **Green Software Foundation**, **W3C Web Sustainability Guidelines**, plus thresholds drawn from **YellowLabTools**), without you having to ask each time.
 
-## Pourquoi un skill plutôt qu'une simple liste de règles
+## Why a skill instead of a plain rule list
 
-Une checklist RGESN en PDF ou en wiki dépend de la mémoire de qui l'a lue une fois. Personne ne la rouvre avant chaque ligne de code, et son application varie d'une personne à l'autre selon qui s'en souvient ce jour-là.
+An RGESN checklist in a PDF or wiki depends on someone remembering to reopen it. Nobody reads it again before every line of code, and how well it's followed varies from person to person, and from day to day.
 
-Un skill Claude Code apporte trois différences concrètes :
+A Claude Code skill makes three concrete differences:
 
-- **Chargement automatique à chaque session.** Le skill se charge tout seul, sans qu'on ait à le mentionner en tête de conversation.
-- **Sélection contextuelle des règles.** Claude applique les familles pertinentes pour ce qu'il écrit à l'instant : un backend déclenche les règles SQL et pools de connexions, pas les règles UX/UI sur l'autoplay.
-- **Vérification a posteriori intégrée.** Le script d'audit (`eco-audit.sh`) tourne à la demande sur le code déjà écrit, sans coût de raisonnement pour le modèle, pour attraper ce que l'application proactive a raté.
+- **Loads automatically every session.** The skill loads itself — no need to mention it at the start of a conversation.
+- **Contextual rule selection.** Claude applies whichever families are relevant to what it's writing right now: a backend file triggers the SQL and connection-pool rules, not the UX/UI rules about autoplay.
+- **Built-in after-the-fact verification.** The audit script (`eco-audit.sh`) runs on demand against code already written, at zero reasoning cost for the model, to catch what proactive application missed.
 
-La checklist reste un document qu'on consulte. Le skill s'exécute au moment où le code s'écrit, dans la session de travail elle-même.
+A checklist stays a document you consult. The skill runs at the moment the code is written, inside the working session itself.
 
 ## Installation
 
-### Via le gestionnaire de plugins de Claude Code (recommandé)
+### Via the Claude Code plugin manager (recommended)
 
 ```
 /plugin marketplace add Institut-du-Numerique-Responsable/green-claude
 /plugin install green-claude@green-claude
 ```
 
-Claude Code gère alors les mises à jour (`/plugin update green-claude`) sans repasser par un `git pull` manuel.
+Claude Code then handles updates (`/plugin update green-claude`) without a manual `git pull`.
 
 ### Via install.sh
 
@@ -56,25 +56,25 @@ cd green-claude
 ./install.sh
 ```
 
-Ça installe le skill dans `~/.claude/skills/green-claude`. Rien d'autre à faire : Claude Code le charge automatiquement dans tes sessions suivantes. Cette méthode reste utile pour câbler en plus les hooks de cache (voir plus bas), que le gestionnaire de plugins ne pose pas automatiquement.
+This installs the skill into `~/.claude/skills/green-claude`. Nothing else to do: Claude Code loads it automatically in your next sessions. This method is still worth using if you also want the optional cache hooks (see below), which the plugin manager doesn't wire up on its own.
 
-Prérequis : `jq`, pour le script d'audit et les hooks (`brew install jq` / `sudo apt install jq`).
+Prerequisite: `jq`, needed by the audit script and the hooks (`brew install jq` / `sudo apt install jq`).
 
-## Utilisation
+## Usage
 
-Rien à taper. Trois façons de s'en servir :
+Nothing to type. Three ways to use it:
 
-| Tu veux... | Ce que tu fais |
+| You want to... | What you do |
 |---|---|
-| Que Claude code sobrement par défaut | Rien : c'est automatique dès que le skill est installé |
-| Auditer un fichier existant | Demande simplement : *« audit éco-conception de ce fichier »* |
-| Voir la checklist complète | Tape `/green-claude` |
+| Have Claude write sober code by default | Nothing: it's automatic once the skill is installed |
+| Audit an existing file | Just ask: *"eco-design audit of this file"* |
+| See the full checklist | Type `/green-claude` |
 
-L'audit (`skills/green-claude/scripts/eco-audit.sh`) est un script déterministe (grep sur les règles) : il ne coûte pas de raisonnement au modèle, juste la lecture du résultat.
+The audit (`skills/green-claude/scripts/eco-audit.sh`) is a deterministic script (grep against the rules): it costs the model no reasoning, only the reading of the result.
 
-## Exemple concret
+## Real example
 
-Ce code, tout à fait banal :
+This entirely ordinary piece of code:
 
 ```js
 import _ from 'lodash';
@@ -86,125 +86,125 @@ app.get('/api/users', (req, res) => {
 });
 ```
 
-`eco-audit.sh api.js` (sortie réelle, non retouchée) :
+`eco-audit.sh api.js` (real, unedited output):
 
 ```
-[Élevé] ECO-FRONT-01 — Pas de bibliothèque lourde pour un besoin mineur
-  Recommandation : Préférer les fonctions natives du langage ou des alternatives légères (date-fns, Alpine.js).
+[High] ECO-FRONT-01 — Avoid heavy libraries for minor needs
+  Recommendation: Prefer native language functions or lightweight alternatives (date-fns, Alpine.js).
 
-[Élevé] ECO-BACK-01 — Optimiser les requêtes SQL
-  Recommandation : Sélectionner uniquement les colonnes nécessaires, indexer les colonnes filtrées, éviter les fonctions dans les clauses WHERE et les requêtes N+1.
+[High] ECO-BACK-01 — Optimize SQL queries
+  Recommendation: Select only the columns you need, index filtered columns, avoid functions in WHERE clauses and N+1 queries.
 
-2 issue(s) d'éco-conception détectée(s).
+2 eco-design issue(s) detected.
 ```
 
-En pratique, tu n'as pas besoin de lancer l'audit toi-même sur ce genre de code : en mode proactif, Claude évite `lodash` pour une seule fonction et `SELECT *` dès l'écriture, avant même qu'un audit ait lieu.
+In practice, you don't need to run the audit yourself on code like this: in proactive mode, Claude avoids `lodash` for a single function and `SELECT *` right when writing the code, before any audit even happens.
 
 ---
 
-## Les règles : 52 règles alignées sur les 9 familles du RGESN 2024
+## The rules: 52 rules aligned with the 9 RGESN 2024 families
 
-[`skills/green-claude/rules/ecoconception.json`](skills/green-claude/rules/ecoconception.json) couvre les **9 familles** du [RGESN 2024](https://www.arcep.fr/mes-demarches-et-services/entreprises/fiches-pratiques/referentiel-general-ecoconception-services-numeriques.html) (78 critères officiels). Chaque règle référence le critère RGESN correspondant (`rgesn_ref`) et la famille [GR491](https://gr491.isit-europe.org/) (`gr491_famille`) :
+[`skills/green-claude/rules/ecoconception.json`](skills/green-claude/rules/ecoconception.json) covers all **9 families** of [RGESN 2024](https://www.arcep.fr/mes-demarches-et-services/entreprises/fiches-pratiques/referentiel-general-ecoconception-services-numeriques.html) (78 official criteria). Each rule references the matching RGESN criterion (`rgesn_ref`) and [GR491](https://gr491.isit-europe.org/) family (`gr491_famille`):
 
-| Famille RGESN | Règles | Exemples |
+| RGESN family | Rules | Examples |
 |---|---|---|
-| 1. Stratégie | 6 | Mesurer avant d'optimiser, données raisonnées, formats ouverts, référent sobriété, sensibilisation, transparence utilisateur |
-| 2. Spécifications | 5 | Compatibilité anciens terminaux, bas débit, impact des services tiers |
-| 3. Architecture | 5 | Low-tech d'abord, ressources adaptées à la charge, environnements de test sobres, code testé et maintenable |
-| 4. UX/UI | 7 | Pas d'autoplay ni de scroll infini, composants natifs, polices limitées, média le plus sobre, prefers-reduced-motion |
-| 5. Contenus | 2 | Images optimisées, SVG |
-| 6. Frontend | 13 | Pas de bibliothèque lourde, lazy loading, minification, dépendances, pas de code mort, pas de globales implicites, pas de XHR synchrone, DOM sobre, pas d'IDs dupliqués, !important limité, pas de CSS dupliqué, pas de hacks IE legacy, scripts différés |
-| 7. Backend | 4 | SQL optimisé, pools de connexions, complexité, pagination + cache |
-| 8. Hébergement | 6 | Hébergeur sobre, compression HTTP, cache HTTP, HTTPS/TLS, liens cassés |
-| 9. **Algorithmie (dont IA)** | 4 | **Justifier l'IA, dimensionner le modèle, mesurer, alternatives sobres** |
+| 1. Strategy | 6 | Measure before optimizing, reasoned data collection, open formats, sustainability advocate, awareness training, user transparency |
+| 2. Specifications | 5 | Compatibility with old devices, low bandwidth, third-party services impact |
+| 3. Architecture | 5 | Low-tech first, resources matched to load, sober test environments, tested and maintainable code |
+| 4. UX/UI | 7 | No autoplay or infinite scroll, native components, limited fonts, most sober medium, prefers-reduced-motion |
+| 5. Content | 2 | Optimized images, SVG |
+| 6. Frontend | 13 | No heavy libraries, lazy loading, minification, dependencies, no dead code, no implicit globals, no synchronous XHR, lean DOM, no duplicate IDs, limited `!important`, no duplicate CSS, no legacy IE hacks, deferred scripts |
+| 7. Backend | 4 | Optimized SQL, connection pools, complexity, pagination + cache |
+| 8. Hosting | 6 | Sober hosting, HTTP compression, HTTP cache, HTTPS/TLS, broken links |
+| 9. **Algorithms (incl. AI)** | 4 | **Justify AI use, right-size the model, measure, sober alternatives** |
 
-Les règles sans motif détectable (démarche, gouvernance) sont ignorées par l'audit et servent de checklist dans `/green-claude`.
+Rules with no detectable pattern (process, governance) are skipped by the audit and serve as a checklist in `/green-claude`.
 
 ---
 
-## Les pratiques Boris : utiliser Claude sobrement et avec bon sens
+## Boris's practices: using Claude soberly and sensibly
 
-Coder avec l'IA a aussi un coût pendant la session elle-même : chaque requête consomme de l'énergie. [Boris Cherny](https://howborisusesclaudecode.com/), créateur de Claude Code, documente des pratiques d'usage efficace. Un usage efficace est aussi un usage sobre : chaque aller-retour évité économise des tokens, chaque contexte allégé aussi.
+Coding with AI also has a cost during the session itself: every request consumes energy. [Boris Cherny](https://howborisusesclaudecode.com/), Claude Code's creator, documents efficient usage practices. Efficient use is also sober use: every avoided back-and-forth saves tokens, every trimmed context does too.
 
-[`skills/green-claude/rules/boris.json`](skills/green-claude/rules/boris.json) en reprend 14, dont deux ajoutées avec des exemples d'outils open source vérifiés :
+[`skills/green-claude/rules/boris.json`](skills/green-claude/rules/boris.json) picks up 14 of them, including two added with verified open-source tool examples:
 
-| Pratique | Le geste |
+| Practice | The move |
 |---|---|
-| Minimalisme de contexte | Prompt minimal, laisser Claude aller chercher le contexte lui-même |
-| Rembobiner plutôt que corriger | `/rewind` (double Échap) au lieu d'empiler des corrections dans le contexte |
-| `/clear` vs `/compact` | Nouvelle tâche → `/clear`. Tâche liée → `/compact <consigne>` |
-| Cartographier le code | Un index du dépôt (CODEMAP.md, ou un outil comme [graphify](https://github.com/Graphify-Labs/graphify)) évite de relire les mêmes fichiers en entier à chaque session |
-| Réponses denses | Aller droit au résultat plutôt que reformuler (l'esprit derrière des outils comme [caveman](https://github.com/juliusbrussee/caveman)) |
-| Écrire la règle, pas re-corriger | « Ajoute ça à CLAUDE.md » répare une fois pour toutes |
-| Une skill pour ce qui se répète | Un workflow quotidien devient une slash command |
-| Donner un moyen de vérifier | Tests, commande, navigateur : moins de cycles de correction |
-| Adapter le niveau d'effort | `/effort low/high/max` selon la tâche, jamais par défaut au maximum |
-| `--bare` pour les scripts | Démarrage sans contexte projet, pour l'automatisation |
+| Context minimalism | Minimal prompt, let Claude fetch its own context |
+| Rewind instead of correcting | `/rewind` (double Esc) instead of stacking corrections into the context |
+| `/clear` vs `/compact` | New task → `/clear`. Related task → `/compact <instruction>` |
+| Map the codebase | A repo index (CODEMAP.md, or a tool like [graphify](https://github.com/Graphify-Labs/graphify)) avoids re-reading the same files whole every session |
+| Dense answers | Get straight to the result instead of rephrasing (the spirit behind tools like [caveman](https://github.com/juliusbrussee/caveman)) |
+| Write the rule, don't re-correct | "Add this to CLAUDE.md" fixes it once and for all |
+| A skill for anything repeated | A daily workflow becomes a slash command |
+| Give it a way to verify | Tests, a command, a browser: fewer correction cycles |
+| Match effort to the task | `/effort low/high/max` depending on the task, never maxed out by default |
+| `--bare` for scripts | Startup with no project context, for automation |
 
-Détail complet : [`skills/green-claude/rules/boris.json`](skills/green-claude/rules/boris.json).
+Full detail: [`skills/green-claude/rules/boris.json`](skills/green-claude/rules/boris.json).
 
-> Les outils tiers cités (graphify, caveman) sont des exemples illustratifs vérifiés (open source, licence MIT). Le projet ne les audite pas et n'en dépend pas.
-
----
-
-## Ce qu'un skill ne peut pas faire (et comment on le couvre quand même)
-
-Un skill s'exécute *pendant* une session déjà lancée. Il ne peut donc pas décider avec quel modèle démarrer, ni empêcher un appel au modèle avant qu'il n'ait lieu. Deux leviers restent donc hors du skill, dans [`hooks/`](hooks/), optionnels et proposés à l'installation :
-
-- **Cache local** (`hooks/green-claude-cache.sh`) : une question déjà posée est resservie sans réappeler le modèle, zéro token consommé.
-- **Avertissement heures creuses** (même hook) : signale les heures de pointe (hors 22h-6h UTC) sans bloquer.
-
-Ces hooks se câblent dans `~/.claude/settings.json`. Si on réponds « o », `install.sh` les y ajoute (les autres réglages sont préservés et une sauvegarde du fichier d'origine est laissée en `settings.json.green-claude.bak`). Sans `jq` il affiche la config à coller à la main. Pour les retirer : supprimer les deux entrées `green-claude-*` du fichier.
+> The third-party tools cited (graphify, caveman) are verified illustrative examples (open source, MIT license). The project doesn't audit them and doesn't depend on them.
 
 ---
 
-## Écrire ses propres règles
+## What a skill can't do (and how it's covered anyway)
 
-Ajoute un fichier JSON dans `skills/green-claude/rules/`, structuré comme `ecoconception.json` (catégories → règles) :
+A skill runs *during* a session that's already started. It can't decide which model to start with, nor prevent a model call before it happens. Two levers therefore live outside the skill, in [`hooks/`](hooks/), optional and offered at install time:
+
+- **Local cache** (`hooks/green-claude-cache.sh`): a question already asked gets served again without calling the model — zero tokens spent.
+- **Off-peak warning** (same hook): flags peak hours (outside 22:00-06:00 UTC) without ever blocking.
+
+These hooks wire into `~/.claude/settings.json`. If you answer "y", `install.sh` adds them there (other settings are preserved, and a backup of the original file is left at `settings.json.green-claude.bak`). Without `jq`, it prints the config to paste in by hand. To remove them: delete the two `green-claude-*` entries from the file.
+
+---
+
+## Writing your own rules
+
+Add a JSON file under `skills/green-claude/rules/`, structured like `ecoconception.json` (categories → rules):
 
 ```json
 {
   "id": "CUSTOM-001",
-  "title": "Ma règle",
-  "impact": "Élevé",
-  "patterns": ["mon_motif_regex"],
-  "recommendation": "Quoi faire à la place."
+  "title": "My rule",
+  "impact": "High",
+  "patterns": ["my_regex_pattern"],
+  "recommendation": "What to do instead."
 }
 ```
 
-- `patterns` : expressions régulières `grep -E` détectant le problème. **Liste vide = pratique** (checklist, ignorée par l'audit).
-- `impact` : `Élevé`, `Moyen` ou `Faible`.
-- `rgesn_ref` / `gr491_famille` (optionnels) : renvoi vers les référentiels officiels.
-- `detector` / `enrich` (optionnels) : pour les cas qu'un pattern seul ne peut pas voir (imbrication multi-lignes, comptage, poids réel d'un fichier référencé...), un script dédié dans `scripts/`. Détail complet dans [CONTRIBUTING.md](CONTRIBUTING.md).
-- `note` (optionnel) : mise en garde affichée dans le résultat de l'audit (faux positif connu, seuil, portée limitée) — l'endroit où documenter les pièges d'interprétation d'une règle, pas dans le skill lui-même.
+- `patterns`: `grep -E` regular expressions detecting the problem. **Empty list = a practice** (checklist item, skipped by the audit).
+- `impact`: `High`, `Medium`, or `Low`.
+- `rgesn_ref` / `gr491_famille` (optional): pointer back to the official standards.
+- `detector` / `enrich` (optional): for cases a pattern alone can't see (multi-line nesting, counting, the real weight of a referenced file...), a dedicated script under `scripts/`. Full detail in [CONTRIBUTING.md](CONTRIBUTING.md).
+- `note` (optional): a caveat shown in the audit's own output (known false positive, threshold, limited scope) — this is where to document a rule's interpretation pitfalls, not in the skill itself.
 
-Relance ensuite `./install.sh` pour republier le skill mis à jour.
-
----
-
-## 🤝 Contribuer
-
-1. **Fork** ce dépôt
-2. Créez une branche (`git checkout -b feature/ma-regle`)
-3. Ajoutez vos règles ou améliorations (`jq empty skills/green-claude/rules/*.json` pour valider le JSON)
-4. Ouvrez une **Pull Request**
-
-Les contributions les plus utiles : nouvelles règles d'audit sourcées (RGESN, GR491, GSF, WSG, ou une autre référence publique reconnue) avec leur `rgesn_ref`, corrections de patterns (faux positifs), traductions.
-
-Détail complet du format des règles et du processus de PR : [CONTRIBUTING.md](CONTRIBUTING.md).
+Then re-run `./install.sh` to republish the updated skill.
 
 ---
 
-## 🙏 Références
+## 🤝 Contributing
 
-- [RGESN 2024](https://ecoresponsable.numerique.gouv.fr/publications/referentiel-general-ecoconception/) : Référentiel Général d'Écoconception de Services Numériques (78 critères, 9 familles)
-- [GR491](https://gr491.isit-europe.org/) : Guide de référence de conception responsable de services numériques (61 recommandations, 516 critères)
-- [Green Software Foundation](https://greensoftware.foundation/) : patterns d'éco-conception logicielle
-- [W3C Web Sustainability Guidelines](https://w3c.github.io/sustainableweb-wsg/) : recommandations de durabilité web (UX, développement, hébergement, stratégie)
-- [YellowLabTools](https://github.com/YellowLabTools/YellowLabTools) : outil open source d'audit de qualité front-end, source de plusieurs seuils (DOM, CSS, polices)
-- [How Boris uses Claude Code](https://howborisusesclaudecode.com/) : les pratiques de Boris Cherny, créateur de Claude Code
-- [Anthropic](https://www.anthropic.com/) : Claude et Claude Code
+1. **Fork** this repository
+2. Create a branch (`git checkout -b feature/my-rule`)
+3. Add your rules or improvements (`jq empty skills/green-claude/rules/*.json` to validate the JSON)
+4. Open a **Pull Request**
 
-## 📄 Licence
+Most useful contributions: new audit rules sourced from RGESN, GR491, GSF, WSG, or another recognized public reference, with their `rgesn_ref`; pattern fixes (false positives); translations.
+
+Full detail on the rule format and PR process: [CONTRIBUTING.md](CONTRIBUTING.md).
+
+---
+
+## 🙏 References
+
+- [RGESN 2024](https://ecoresponsable.numerique.gouv.fr/publications/referentiel-general-ecoconception/): Référentiel Général d'Écoconception de Services Numériques (78 criteria, 9 families)
+- [GR491](https://gr491.isit-europe.org/): reference guide for responsible digital service design (61 recommendations, 516 criteria)
+- [Green Software Foundation](https://greensoftware.foundation/): software eco-design patterns
+- [W3C Web Sustainability Guidelines](https://w3c.github.io/sustainableweb-wsg/): web sustainability guidelines (UX, development, hosting, strategy)
+- [YellowLabTools](https://github.com/YellowLabTools/YellowLabTools): open-source front-end quality audit tool, source of several thresholds (DOM, CSS, fonts)
+- [How Boris uses Claude Code](https://howborisusesclaudecode.com/): Boris Cherny's practices, Claude Code's creator
+- [Anthropic](https://www.anthropic.com/): Claude and Claude Code
+
+## 📄 License
 
 [MIT](LICENSE), © 2026 Institut du Numérique Responsable


### PR DESCRIPTION
## Pourquoi

Le dépôt GitHub et la soumission au marketplace communautaire sont à audience internationale/anglophone par défaut ; un README uniquement en français est une vraie barrière à la découverte pour qui ne lit pas le français.

## Ce qui change

- `README.md` devient la version anglaise (celle que GitHub affiche par défaut).
- `README.fr.md` préserve la version française d'origine.
- Lien de bascule de langue en haut de chaque fichier (🇬🇧/🇫🇷).

La page (`docs/index.html`) reste en français : public déjà francophone via l'INR, et l'ancre `#installation` référencée depuis la page reste valide dans les deux langues (« Installation » identique en français et en anglais).

Aucune autre référence à `README.md` ailleurs dans le dépôt (`CONTRIBUTING.md`, `SKILL.md`, `install.sh`) ne nécessitait d'ajustement — vérifié avant de committer.

## Vérifié

`jq empty`, `scripts/test-eco-audit.sh` (21/21), `claude plugin validate` — rien de ces changements ne touche au skill lui-même.