### PR TITLE
Ajoute une section Mainteneurs (README) et des topics GitHub

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -207,6 +207,10 @@ Détail complet du format des règles et du processus de PR : [CONTRIBUTING.md](
 - [How Boris uses Claude Code](https://howborisusesclaudecode.com/) : les pratiques de Boris Cherny, créateur de Claude Code
 - [Anthropic](https://www.anthropic.com/) : Claude et Claude Code
 
+## Mainteneurs
+
+- [Guillaume Gallon](https://github.com/gridboy) ([LinkedIn](https://www.linkedin.com/in/ggallon/)) — [Institut du Numérique Responsable](https://institutnr.org)
+
 ## 📄 Licence
 
 [MIT](LICENSE), © 2026 Institut du Numérique Responsable

--- a/README.md
+++ b/README.md
@@ -205,6 +205,10 @@ Full detail on the rule format and PR process: [CONTRIBUTING.md](CONTRIBUTING.md
 - [How Boris uses Claude Code](https://howborisusesclaudecode.com/): Boris Cherny's practices, Claude Code's creator
 - [Anthropic](https://www.anthropic.com/): Claude and Claude Code
 
+## Maintainers
+
+- [Guillaume Gallon](https://github.com/gridboy) ([LinkedIn](https://www.linkedin.com/in/ggallon/)) — [Institut du Numérique Responsable](https://institutnr.org)
+
 ## 📄 License
 
 [MIT](LICENSE), © 2026 Institut du Numérique Responsable


### PR DESCRIPTION
Deux leviers de visibilité distincts :

- **Topics GitHub du dépôt** : ajout de `claude-code-plugin`, `gr491`, `web-sustainability` aux 15 déjà en place — améliore le référencement dans la recherche/le parcours GitHub.
- **Section « Maintainers »/« Mainteneurs »** dans les deux README, avec lien vers le profil GitHub et LinkedIn — jusqu'ici la seule mention nominative dans tout le projet était la `source_note` de la règle `ECO-ARCH-05`.

Vérifié : `jq empty`, `scripts/test-eco-audit.sh` (21/21), `claude plugin validate`.