### PR TITLE
Ajoute la balise de vérification Google Search Console

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -7,6 +7,7 @@
   <meta name="description" content="Green Claude : skill open source pour Claude Code, code éco-conçu selon le RGESN 2024, le GR491 et d'autres référentiels reconnus.">
   <meta name="author" content="Institut du Numérique Responsable">
   <meta name="robots" content="index, follow">
+  <meta name="google-site-verification" content="jgumEgIuIzTPIIrXW3ot-CFd51RTcmmTdRNcSlqf2MA" />
   <link rel="canonical" href="https://institut-du-numerique-responsable.github.io/green-claude/">
   <meta property="og:title" content="Green Claude : sobriété numérique pour Claude Code">
   <meta property="og:description" content="Skill open source pour Claude Code : code éco-conçu par défaut (RGESN 2024 / GR491 / WSG), plus un hook optionnel de cache local et heures creuses.">


### PR DESCRIPTION
Permet de vérifier la propriété du site sur Google Search Console (indexation plus rapide, données de recherche réelles, détection d'erreurs de crawl).