### PR TITLE
Hook d'audit éco-conception après chaque écriture de code

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -151,12 +151,13 @@ Détail complet : [`skills/green-claude/rules/boris.json`](skills/green-claude/r
 
 ## Ce qu'un skill ne peut pas faire (et comment on le couvre quand même)
 
-Un skill s'exécute *pendant* une session déjà lancée. Il ne peut donc pas décider avec quel modèle démarrer, ni empêcher un appel au modèle avant qu'il n'ait lieu. Deux leviers restent donc hors du skill, dans [`hooks/`](hooks/), optionnels et proposés à l'installation :
+Un skill s'exécute *pendant* une session déjà lancée, et c'est le modèle qui décide de l'appliquer. Il ne choisit donc pas le modèle de démarrage, n'intercepte pas un appel avant qu'il parte, et ne garantit pas qu'une règle soit vérifiée à tous les coups. Trois leviers restent hors du skill, dans [`hooks/`](hooks/), optionnels et proposés à l'installation :
 
+- **Audit systématique** (`hooks/green-claude-audit.sh`) : câblé en `PostToolUse` sur `Write|Edit|MultiEdit`. Claude Code l'exécute après chaque écriture de fichier de code, sans demander son avis au modèle. Le hook audite ce qui vient d'être ajouté et renvoie les motifs trouvés à Claude, qui corrige avant de continuer.
 - **Cache local** (`hooks/green-claude-cache.sh`) : une question déjà posée est resservie sans réappeler le modèle, zéro token consommé.
 - **Avertissement heures creuses** (même hook) : signale les heures de pointe (hors 22h-6h UTC) sans bloquer.
 
-Ces hooks se câblent dans `~/.claude/settings.json`. Si on réponds « o », `install.sh` les y ajoute (les autres réglages sont préservés et une sauvegarde du fichier d'origine est laissée en `settings.json.green-claude.bak`). Sans `jq` il affiche la config à coller à la main. Pour les retirer : supprimer les deux entrées `green-claude-*` du fichier.
+Ces hooks se câblent dans `~/.claude/settings.json`. Si on répond « o », `install.sh` les y ajoute (les autres réglages sont préservés et une sauvegarde du fichier d'origine est laissée en `settings.json.green-claude.bak`). Sans `jq` il affiche la config à coller à la main. Pour les retirer : supprimer les entrées `green-claude-*` du fichier.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -149,12 +149,13 @@ Full detail: [`skills/green-claude/rules/boris.json`](skills/green-claude/rules/
 
 ## What a skill can't do (and how it's covered anyway)
 
-A skill runs *during* a session that's already started. It can't decide which model to start with, nor prevent a model call before it happens. Two levers therefore live outside the skill, in [`hooks/`](hooks/), optional and offered at install time:
+A skill runs *during* a session that's already started, and the model decides whether to apply it. So it can't pick the starting model, can't intercept a call before it leaves, and can't guarantee a rule gets checked every single time. Three levers therefore live outside the skill, in [`hooks/`](hooks/), optional and offered at install time:
 
+- **Systematic audit** (`hooks/green-claude-audit.sh`): wired as `PostToolUse` on `Write|Edit|MultiEdit`. Claude Code runs it after every code file written, without asking the model. It audits what was just added and hands the findings back to Claude, who fixes them before moving on.
 - **Local cache** (`hooks/green-claude-cache.sh`): a question already asked gets served again without calling the model — zero tokens spent.
 - **Off-peak warning** (same hook): flags peak hours (outside 22:00-06:00 UTC) without ever blocking.
 
-These hooks wire into `~/.claude/settings.json`. If you answer "y", `install.sh` adds them there (other settings are preserved, and a backup of the original file is left at `settings.json.green-claude.bak`). Without `jq`, it prints the config to paste in by hand. To remove them: delete the two `green-claude-*` entries from the file.
+These hooks wire into `~/.claude/settings.json`. If you answer "y", `install.sh` adds them there (other settings are preserved, and a backup of the original file is left at `settings.json.green-claude.bak`). Without `jq`, it prints the config to paste in by hand. To remove them: delete the `green-claude-*` entries from the file.
 
 ---
 

--- a/hooks/green-claude-audit.sh
+++ b/hooks/green-claude-audit.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# Hook PostToolUse (Write|Edit|MultiEdit) — ce qu'un skill ne peut pas garantir :
+# le skill est déclenché par le modèle, donc de façon probabiliste. Ce hook est
+# exécuté par le harnais après CHAQUE écriture de fichier : l'audit passe, que
+# Claude y ait pensé ou non.
+#
+# N'audite que le contenu introduit par l'écriture (new_string / content), pas
+# tout le fichier : sinon chaque édition d'un fichier existant re-signale des
+# motifs préexistants que la tâche en cours n'a pas introduits.
+#
+# Sortie code 2 = le rapport est réinjecté à Claude, qui corrige avant de
+# poursuivre. Aucune issue = silence complet.
+#
+# À déclarer dans ~/.claude/settings.json (voir install.sh) :
+#   "hooks": { "PostToolUse": [{"matcher": "Write|Edit|MultiEdit",
+#     "hooks": [{"type": "command", "command": "~/.claude/hooks/green-claude-audit.sh"}]}] }
+
+set -uo pipefail
+
+AUDIT="$HOME/.claude/skills/green-claude/scripts/eco-audit.sh"
+[ -x "$AUDIT" ] || exit 0            # skill absent : le hook ne casse rien
+command -v jq >/dev/null 2>&1 || exit 0
+
+INPUT="$(cat)"
+FILE="$(jq -r '.tool_input.file_path // empty' <<<"$INPUT")"
+[ -n "$FILE" ] || exit 0
+
+EXT="$(printf '%s' "${FILE##*.}" | tr '[:upper:]' '[:lower:]')"
+[ "$EXT" != "$(printf '%s' "$FILE" | tr '[:upper:]' '[:lower:]')" ] || exit 0
+
+# Uniquement du code : sur un .md ou un .json, les patterns des règles décrivent
+# le sujet du document, pas un défaut à corriger (« penser à éviter SELECT * »).
+case "$EXT" in
+    py|js|jsx|ts|tsx|mjs|cjs|sql|pks|pkb|prc|fnc|trg|java|cs|php|rb|rs|c|h|cpp|cc|cxx|hpp|hh|go|kt|swift|scala|html|htm|css|scss|sass|vue|svelte|sh|bash) ;;
+    *) exit 0 ;;
+esac
+
+# Contenu écrit : Write -> .content, Edit -> .new_string, MultiEdit -> tous les
+# .edits[].new_string. Repli sur le fichier complet si rien n'est exploitable.
+ADDED="$(jq -r '
+    .tool_input
+    | (.content // .new_string // ([.edits[]?.new_string] | join("\n")) // empty)' <<<"$INPUT")"
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+TARGET="$TMP_DIR/ajout.$EXT"
+
+if [ -n "$ADDED" ]; then
+    printf '%s\n' "$ADDED" > "$TARGET"
+elif [ -f "$FILE" ]; then
+    cp "$FILE" "$TARGET"
+else
+    exit 0
+fi
+
+REPORT="$("$AUDIT" "$TARGET" 2>/dev/null)" || exit 0
+grep -q '^\[' <<<"$REPORT" || exit 0  # aucune issue : silence
+
+# Le chemin temporaire n'a aucun sens pour Claude : on remet le vrai fichier.
+REPORT="${REPORT//$TARGET/$FILE}"
+
+cat >&2 <<EOF
+[Green Claude] Éco-conception — motifs détectés dans ce que tu viens d'écrire ($FILE) :
+
+$REPORT
+Corrige ce qui est pertinent (impact Élevé en priorité). Si un signalement ne
+s'applique pas au contexte, dis-le en une phrase et poursuis : ces règles ne
+doivent jamais bloquer une demande légitime.
+EOF
+exit 2

--- a/install.sh
+++ b/install.sh
@@ -20,6 +20,21 @@ HOOKS_DIR="$HOME/.claude/hooks"
 SETTINGS_FILE="$HOME/.claude/settings.json"
 CACHE_HOOK="~/.claude/hooks/green-claude-cache.sh"
 SAVE_HOOK="~/.claude/hooks/green-claude-cache-save.sh"
+AUDIT_HOOK="~/.claude/hooks/green-claude-audit.sh"
+
+# Idempotent : un hook déjà déclaré, sous n'importe quelle forme de chemin,
+# n'est pas réajouté. Les hooks existants sont préservés. $4 (facultatif) est
+# le matcher, requis pour les événements liés à un outil comme PostToolUse.
+wire_hook() { # $1 = événement, $2 = commande, $3 = fichier source, $4 = matcher
+    jq --arg e "$1" --arg c "$2" --arg s "/${2##*/}" --arg m "${4:-}" '
+      if [.. | objects | .command? // empty] | any(. == $c or endswith($s)) then .
+      else
+        (if $m == "" then {hooks: [{type: "command", command: $c}]}
+         else {matcher: $m, hooks: [{type: "command", command: $c}]}
+         end) as $entry
+        | .hooks[$e] = ((.hooks[$e] // []) + [$entry])
+      end' "$3"
+}
 
 print_error()   { echo -e "${RED}[ERREUR]${NC} $1"; }
 print_success() { echo -e "${GREEN}[OK]${NC} $1"; }
@@ -63,15 +78,6 @@ if [[ $REPLY =~ ^[OoYy]$ ]]; then
     chmod +x "$HOOKS_DIR/green-claude-cache.sh" "$HOOKS_DIR/green-claude-cache-save.sh"
     print_success "Scripts de hook copiés dans $HOOKS_DIR"
 
-    # Idempotent : un hook déjà déclaré, sous n'importe quelle forme de chemin,
-    # n'est pas réajouté. Les hooks existants sont préservés.
-    wire_hook() { # $1 = événement, $2 = commande, $3 = fichier source
-        jq --arg e "$1" --arg c "$2" --arg s "/${2##*/}" '
-          if [.. | objects | .command? // empty] | any(. == $c or endswith($s)) then .
-          else .hooks[$e] = ((.hooks[$e] // []) + [{hooks: [{type: "command", command: $c}]}])
-          end' "$3"
-    }
-
     WIRED=0
     if command -v jq >/dev/null 2>&1; then
         [ -s "$SETTINGS_FILE" ] || echo '{}' > "$SETTINGS_FILE"
@@ -98,6 +104,46 @@ if [[ $REPLY =~ ^[OoYy]$ ]]; then
     fi
 else
     print_info "Hook ignoré — installable plus tard depuis $SCRIPT_DIR/hooks/"
+fi
+
+# =============================================================================
+# Étape 3 : hook d'audit (PostToolUse)
+# Le skill est chargé sur décision du modèle, donc appliqué souvent mais jamais
+# garanti. Ce hook, lui, est exécuté par Claude Code après chaque écriture de
+# fichier de code, sans passer par cette décision.
+# =============================================================================
+print_info ""
+read -p "Installer le hook d'audit après chaque écriture de code (PostToolUse) ? (o/n) : " -n 1 -r
+echo
+if [[ $REPLY =~ ^[OoYy]$ ]]; then
+    mkdir -p "$HOOKS_DIR"
+    cp "$SCRIPT_DIR/hooks/green-claude-audit.sh" "$HOOKS_DIR/"
+    chmod +x "$HOOKS_DIR/green-claude-audit.sh"
+    print_success "Script d'audit copié dans $HOOKS_DIR"
+
+    AUDIT_WIRED=0
+    if command -v jq >/dev/null 2>&1; then
+        [ -s "$SETTINGS_FILE" ] || echo '{}' > "$SETTINGS_FILE"
+        TMP="$(mktemp)"
+        if wire_hook "PostToolUse" "$AUDIT_HOOK" "$SETTINGS_FILE" "Write|Edit|MultiEdit" > "$TMP" \
+           && [ -s "$TMP" ]; then
+            [ -f "$SETTINGS_FILE.green-claude.bak" ] || cp "$SETTINGS_FILE" "$SETTINGS_FILE.green-claude.bak"
+            mv "$TMP" "$SETTINGS_FILE"
+            AUDIT_WIRED=1
+            print_success "Hook d'audit câblé dans $SETTINGS_FILE"
+            print_info "Redémarre Claude Code pour l'activer."
+        else
+            print_error "jq n'a pas pu traiter $SETTINGS_FILE, fichier laissé intact."
+        fi
+        rm -f "$TMP"
+    fi
+
+    if [ "$AUDIT_WIRED" -eq 0 ]; then
+        print_warning "Câblage à faire à la main dans $SETTINGS_FILE :"
+        printf '\n  {\n    "hooks": {\n      "PostToolUse": [\n        {\n          "matcher": "Write|Edit|MultiEdit",\n          "hooks": [{ "type": "command", "command": "%s" }]\n        }\n      ]\n    }\n  }\n\n' "$AUDIT_HOOK"
+    fi
+else
+    print_info "Hook d'audit ignoré — installable plus tard depuis $SCRIPT_DIR/hooks/"
 fi
 
 # =============================================================================

--- a/skills/green-claude/SKILL.md
+++ b/skills/green-claude/SKILL.md
@@ -75,6 +75,15 @@ détecteur pour cette règle (faux positif connu, seuil, portée...) — c'est
 l'information à jour, plutôt qu'une liste séparée ici qui se périmerait à
 chaque nouvelle règle.
 
+## Garantie d'application
+
+Charger ce skill reste une décision du modèle : ça arrive souvent, pas à tous les
+coups. Pour une vérification qui ne dépende de personne, le dépôt fournit
+`hooks/green-claude-audit.sh`, câblé en `PostToolUse` sur `Write|Edit|MultiEdit`.
+Claude Code l'exécute après chaque écriture de fichier de code et te renvoie les
+motifs trouvés. N'audite que le contenu ajouté par l'écriture, et reste muet
+quand il ne trouve rien.
+
 ## Ce que ce skill ne fait PAS
 
 Le cache de réponses « zéro token » ne peut pas être géré par un skill : il doit


### PR DESCRIPTION
## Pourquoi

Un skill est chargé sur décision du modèle. Ça marche souvent, ça ne se prouve pas. Pour une équipe qui veut que la règle soit vérifiée à chaque fois, il faut un mécanisme que le modèle ne peut pas sauter.

## Ce que ça ajoute

`hooks/green-claude-audit.sh`, câblé en `PostToolUse` sur `Write|Edit|MultiEdit`. Claude Code l'exécute après chaque écriture, hors de toute décision du modèle.

Trois choix de conception :

- **Il n'audite que le contenu ajouté** (`content`, `new_string`, `edits[].new_string`), pas le fichier entier. Sinon la moindre édition d'un fichier existant ressort des motifs préexistants que la tâche en cours n'a pas introduits, et le hook devient du bruit qu'on apprend à ignorer.
- **Liste blanche d'extensions de code.** Un `.md` ou un `.json` qui *mentionne* `SELECT *` n'en contient pas.
- **Échec ouvert.** Skill absent ou `jq` manquant : sortie 0, rien ne casse.

Sortie en code 2 quand des motifs sont détectés, ce qui renvoie le rapport à Claude pour correction avant de poursuivre. Silence complet sinon.

## install.sh

Le hook est proposé à l'installation, jamais imposé, et câblé avec le `wire_hook` déjà en place. Celui-ci gagne un quatrième paramètre facultatif, le matcher, requis par les événements liés à un outil comme `PostToolUse`.

Vérifié sur un `HOME` de test : deux installations successives ne laissent qu'une seule entrée `PostToolUse`, les hooks de cache existants sont préservés, et le fichier d'origine est sauvegardé comme avant.

## Tests

Charges utiles envoyées directement au hook : Edit fautif en Python (sortie 2), écriture propre (sortie 0), fichier sans extension (sortie 0), `.md` mentionnant les motifs (sortie 0), MultiEdit SQL (deux motifs), extension en majuscules (détectée).

## Dépendance

Cette PR ne dépend pas de #26, mais les deux touchent aux mêmes sections de README. À merger dans l'ordre qui vous arrange, avec un conflit trivial à trancher sur la seconde.