### PR TITLE
Ne plus signaler la prose, les commentaires et les mots isolés

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,6 +63,12 @@ Ces règles ne sont testées que sur les fichiers de leur langage, ce qui autori
 
 Les pratiques d'usage sobre de Claude Code vivent dans `skills/green-claude/rules/boris.json`, sur le même principe. Si vous citez un outil tiers en exemple, vérifiez qu'il est open source et sous une licence permissive avant de l'ajouter.
 
+## Ce que l'audit ne lit pas
+
+Avant de chercher les motifs, `eco-audit.sh` retire les commentaires et, dans les fichiers de balisage, le texte rédigé : seuls l'intérieur des balises et les blocs `<script>`/`<style>` sont conservés. Un fichier qui *parle* d'autoplay ou de `SELECT *` n'en contient pas pour autant, et du code commenté ne s'exécute pas. Les détecteurs awk, eux, travaillent sur le fichier d'origine, dont ils ont besoin pour les numéros de ligne et la structure des blocs.
+
+Écrivez donc vos motifs pour du code réel. Un motif qui repose sur un mot isolé (`vue`, `next`, `autoplay`) se déclenche sur de la prose française et sur des mots-clés de langage : ancrez-le dans sa syntaxe (`from "vue"`, `autoplay=`).
+
 ## Corriger un faux positif
 
 Si un pattern regex déclenche l'audit à tort, ouvrez une PR qui resserre l'expression régulière et expliquez le cas limite rencontré dans la description de la PR.

--- a/skills/green-claude/rules/ecoconception.json
+++ b/skills/green-claude/rules/ecoconception.json
@@ -208,13 +208,12 @@
           "description": "Un framework lourd pour un site vitrine, c'est du JavaScript téléchargé, parsé et exécuté par chaque visiteur pour rien.",
           "impact": "Élevé",
           "patterns": [
-            "\\breact\\b",
-            "\\bangular\\b",
-            "\\bvue\\b",
-            "\\bnext\\b"
+            "from\\s+['\"](react|react-dom|vue|@angular/[a-z]+|next)['\"]",
+            "require\\(\\s*['\"](react|react-dom|vue|@angular/[a-z]+|next)['\"]",
+            "\"(react|react-dom|vue|@angular/core|next|nuxt)\"\\s*:\\s*['\"]?[\\^~0-9]"
           ],
           "recommendation": "Avant d'adopter un framework, évaluer si du HTML/CSS statique, du Vanilla JS ou HTMX suffisent au besoin réel.",
-          "note": "Vise le choix initial d'architecture pour un besoin simple, pas un projet déjà construit sur un de ces frameworks : ne resignale pas à chaque audit d'un projet existant.",
+          "note": "Le nom du framework doit apparaître dans un import, un require ou une dépendance déclarée : cherché comme simple mot, « vue » signale n'importe quel texte français et « next » n'importe quelle boucle awk ou JS.",
           "rgesn_ref": "3.1",
           "gr491_famille": "Architecture",
           "tags": [
@@ -301,7 +300,9 @@
           "description": "L'autoplay télécharge et décode de la vidéo, du son ou des animations que l'utilisateur n'a pas demandés — le pire ratio utilité/consommation du web.",
           "impact": "Élevé",
           "patterns": [
-            "autoplay"
+            "<(video|audio|iframe)[^>]*autoplay",
+            "autoplay\\s*[=:]",
+            "autoPlay"
           ],
           "recommendation": "Remplacer l'autoplay par une image de couverture cliquable (façade) ; ne charger le média qu'au clic.",
           "rgesn_ref": "4.1",
@@ -310,7 +311,8 @@
             "video",
             "autoplay",
             "energie"
-          ]
+          ],
+          "note": "Le mot « autoplay » seul ne suffit pas : seuls l'attribut HTML et la propriété JS sont cherchés, sinon toute page qui parle d'autoplay est signalée."
         },
         {
           "id": "ECO-UX-02",

--- a/skills/green-claude/scripts/eco-audit.sh
+++ b/skills/green-claude/scripts/eco-audit.sh
@@ -12,6 +12,82 @@ RULES_FILE="$SCRIPT_DIR/../rules/ecoconception.json"
 BORIS_FILE="$SCRIPT_DIR/../rules/boris.json"
 LANG_DIR="$SCRIPT_DIR/../rules/langages"
 
+# Le texte rédigé n'est pas du code. Un fichier qui *parle* d'autoplay ou de
+# SELECT * n'en contient pas pour autant, et le signaler use la crédibilité de
+# l'audit. On retire donc, avant de chercher les motifs :
+#   - le texte des pages de balisage, en ne gardant que l'intérieur des balises
+#     (donc les attributs) et les blocs <script>/<style>, qui sont bien du code ;
+#   - les commentaires, prose ou code désactivé. Du code commenté ne s'exécute
+#     pas, donc ne consomme rien.
+# Les détecteurs awk, eux, travaillent sur le fichier d'origine : ils ont besoin
+# des numéros de ligne réels et de la structure complète des blocs.
+clean_source() {
+    local file="$1" ext line_comment="" block=0
+    ext="$(printf '%s' "${1##*.}" | tr '[:upper:]' '[:lower:]')"
+
+    case "$ext" in
+        py|rb|sh|bash)                          line_comment='^[[:space:]]*#' ;;
+        sql|pks|pkb|prc|fnc|trg)                line_comment='^[[:space:]]*--' ;;
+        js|jsx|ts|tsx|mjs|cjs|java|cs|php|rs|go|kt|swift|scala|c|h|cpp|cc|cxx|hpp|hh)
+                                                line_comment='^[[:space:]]*//'; block=1 ;;
+        css|scss|sass)                          block=1 ;;
+    esac
+
+    case "$ext" in
+        html|htm|vue|svelte) strip_markup_text "$file" ;;
+        *)                   cat "$file" ;;
+    esac | awk -v lc="$line_comment" -v block="$block" '
+        block && inblock {
+            if ($0 ~ /\*\//) { sub(/^.*\*\//, ""); inblock = 0 } else { next }
+        }
+        block {
+            while (match($0, /\/\*.*\*\//)) {
+                $0 = substr($0, 1, RSTART - 1) " " substr($0, RSTART + RLENGTH)
+            }
+            if (match($0, /\/\*/)) { $0 = substr($0, 1, RSTART - 1); inblock = 1 }
+        }
+        lc != "" && $0 ~ lc { next }
+        { print }'
+}
+
+# Contenu textuel des pages de balisage : seuls l'intérieur des balises et les
+# blocs <script>/<style> sont conservés. Les commentaires HTML disparaissent
+# avec le reste du texte.
+strip_markup_text() {
+    awk '
+    {
+        line = $0
+        low = tolower(line)
+        if (!raw && low ~ /<(script|style)[ >]/) {
+            print line
+            if (low !~ /<\/(script|style)>/) raw = 1
+            next
+        }
+        if (raw) {
+            print line
+            if (low ~ /<\/(script|style)>/) raw = 0
+            next
+        }
+        if (incomment) {
+            if (match(line, /-->/)) { line = substr(line, RSTART + 3); incomment = 0 }
+            else next
+        }
+        while (match(line, /<!--.*-->/)) {
+            line = substr(line, 1, RSTART - 1) " " substr(line, RSTART + RLENGTH)
+        }
+        if (match(line, /<!--/)) { line = substr(line, 1, RSTART - 1); incomment = 1 }
+        out = ""
+        n = length(line)
+        for (i = 1; i <= n; i++) {
+            c = substr(line, i, 1)
+            if (c == "<") intag = 1
+            if (intag) out = out c
+            if (c == ">") { intag = 0; out = out " " }
+        }
+        print out
+    }' "$1"
+}
+
 # Fichier de règles du langage correspondant à une extension, vide si non couvert.
 lang_file_for_ext() {
     local ext lang
@@ -93,6 +169,16 @@ fi
 
 issues_found=0
 
+# Version nettoyée de chaque fichier, calculée une fois pour toutes plutôt qu'à
+# chaque règle. Pas de tableau associatif pour la retrouver : bash 3.2, livré
+# avec macOS, ne les connaît pas.
+CLEAN_DIR="$(mktemp -d)"
+cleaned_name() { printf '%s' "$1" | tr '/ ' '__'; }
+for arg in "$@"; do
+    [ -f "$arg" ] || continue
+    clean_source "$arg" > "$CLEAN_DIR/$(cleaned_name "$arg")"
+done
+
 # Règles propres aux langages réellement présents parmi les fichiers audités :
 # inutile de charger les dix fichiers pour auditer un seul script Python. Chaque
 # règle porte alors la liste des extensions auxquelles elle s'applique, et n'est
@@ -112,7 +198,7 @@ for arg in "$@"; do
         | .[]
         | select((.patterns // []) | length > 0)' "$lang_json" >> "$lang_rules"
 done
-trap 'rm -f "$lang_rules" "$lang_rules.seen"' EXIT
+trap 'rm -rf "$lang_rules" "$lang_rules.seen" "$CLEAN_DIR"' EXIT
 
 # Une ligne JSON compacte par règle (jq -c) : pas de délimiteur maison à
 # échapper (l'ancien découpage TSV cassait les patterns contenant des
@@ -153,10 +239,15 @@ while IFS= read -r rule_json; do
             detector_script="$SCRIPT_DIR/detect-$(echo "$detector" | tr '_' '-').awk"
             [ -f "$detector_script" ] || continue
             matches=$(awk -f "$detector_script" "$file" 2>/dev/null || true)
-        elif [ -n "$patterns" ] && [ -n "$excludes" ]; then
-            matches=$(grep -iE "$patterns" "$file" 2>/dev/null | grep -qvE "$excludes" && echo "match" || true)
         elif [ -n "$patterns" ]; then
-            matches=$(grep -qiE "$patterns" "$file" 2>/dev/null && echo "match" || true)
+            # Motifs cherchés sur la version nettoyée (sans prose ni commentaires).
+            scanned="$CLEAN_DIR/$(cleaned_name "$file")"
+            [ -f "$scanned" ] || scanned="$file"
+            if [ -n "$excludes" ]; then
+                matches=$(grep -iE "$patterns" "$scanned" 2>/dev/null | grep -qvE "$excludes" && echo "match" || true)
+            else
+                matches=$(grep -qiE "$patterns" "$scanned" 2>/dev/null && echo "match" || true)
+            fi
         fi
         if [ -n "$matches" ]; then
             echo "[$impact] $id — $title"

--- a/skills/green-claude/scripts/test-eco-audit.sh
+++ b/skills/green-claude/scripts/test-eco-audit.sh
@@ -413,4 +413,46 @@ OUT="$(bash eco-audit.sh "$TMP/cache_ok.rb")"
 echo "$OUT" | grep -q 'ECO-RB-06' && fail "exclude_patterns ignoré : cache avec expires_in signalé à tort"
 true
 
-echo "OK - 26 verifications passees"
+# 27. Prose et commentaires : un fichier qui *parle* d'un motif n'en contient
+# pas pour autant. Vaut pour le texte des pages de balisage comme pour les
+# commentaires de code, y compris quand ils citent du code désactivé.
+cat > "$TMP/prose.html" <<'EOF'
+<!-- On évite autoplay et SELECT * dans ce projet -->
+<p>L'audit détecte SELECT *, les bibliothèques lourdes et l'autoplay.</p>
+EOF
+OUT="$(bash eco-audit.sh "$TMP/prose.html")"
+echo "$OUT" | grep -q 'ECO-BACK-01' && fail "faux positif : SELECT * cité dans du texte HTML"
+echo "$OUT" | grep -q 'ECO-UX-01' && fail "faux positif : autoplay cité dans du texte HTML"
+
+cat > "$TMP/commente.py" <<'EOF'
+# Ce module évite SELECT * et n'utilise plus Article.objects.all()
+def liste(session, url):
+    return session.get(url).json()
+EOF
+OUT="$(bash eco-audit.sh "$TMP/commente.py")"
+echo "$OUT" | grep -q 'ECO-BACK-01' && fail "faux positif : SELECT * cité dans un commentaire Python"
+echo "$OUT" | grep -q 'ECO-PY-02' && fail "faux positif : queryset cité dans un commentaire Python"
+true
+
+# 28. Le vrai code, lui, reste détecté : attribut autoplay et bloc <script>.
+cat > "$TMP/media.html" <<'EOF'
+<video autoplay src="promo.mp4"></video>
+EOF
+OUT="$(bash eco-audit.sh "$TMP/media.html")"
+echo "$OUT" | grep -q 'ECO-UX-01' || fail "attribut autoplay réel non détecté"
+
+# 29. Noms de frameworks : cherchés comme simples mots, « vue » signale tout
+# texte français et « next » toute boucle. Il faut un import ou une dépendance.
+cat > "$TMP/appli.jsx" <<'EOF'
+import React from "react";
+EOF
+cat > "$TMP/vue-francaise.js" <<'EOF'
+const total = items.length;
+EOF
+OUT="$(bash eco-audit.sh "$TMP/appli.jsx")"
+echo "$OUT" | grep -q 'ECO-ARCH-01' || fail "import React réel non détecté"
+OUT="$(bash eco-audit.sh "$TMP/vue-francaise.js")"
+echo "$OUT" | grep -q 'ECO-ARCH-01' && fail "faux positif : framework signalé sans import ni dépendance"
+true
+
+echo "OK - 29 verifications passees"


### PR DESCRIPTION
> Empilée sur #26 (base : `feat/regles-par-langage`). À merger après elle ; GitHub rebasera automatiquement la base sur `main` une fois #26 fusionnée.

## Les trois faux positifs

Constatés sur ce dépôt même, en faisant tourner l'audit sur ses propres fichiers :

| Fichier | Signalement | Réalité |
|---|---|---|
| `docs/index.html` | `ECO-UX-01`, `ECO-BACK-01` | La page *parle* d'autoplay et de `SELECT *` dans son texte |
| `scripts/eco-audit.sh` | `ECO-UX-01`, `ECO-BACK-01`, `ECO-ARCH-01` | Ses propres commentaires citent les motifs |
| N'importe quel fichier français | `ECO-ARCH-01` | Le motif `\bvue\b` signale le mot « vue », et `\bnext\b` toute boucle awk ou JS |

Un faux positif coûte plus cher qu'une détection manquée. Au bout de trois alertes à tort, l'audit entier passe pour du bruit et personne ne le lit.

## Ce que ça change

**Nettoyage avant recherche**, une fois par fichier :

- Pages de balisage : seuls l'intérieur des balises (donc les attributs) et les blocs `<script>`/`<style>` sont conservés. Le texte rédigé et les commentaires HTML sautent.
- Commentaires de ligne (`#`, `//`, `--`) et blocs `/* */`, selon le langage. Effet de bord assumé : du code mis en commentaire n'est plus audité, ce qui est cohérent puisqu'il ne s'exécute pas.

Les détecteurs awk continuent de travailler sur le fichier d'origine : ils ont besoin des numéros de ligne réels et de la structure complète des blocs.

**Motifs resserrés**, chacun avec la `note` qui explique la limite là où elle vit, dans la règle :

- `ECO-UX-01` : l'attribut ou la propriété (`<video … autoplay>`, `autoplay=`, `autoPlay`), plus le mot seul.
- `ECO-ARCH-01` : un import, un `require` ou une dépendance déclarée.

## Tests

De 26 à 29 vérifications, chacune dans les deux sens : silence sur la prose HTML et les commentaires Python citant les motifs, détection maintenue sur un vrai `<video autoplay>` et un vrai `import React`.

## Note d'implémentation

Le nettoyage est calculé une seule fois par fichier avant la boucle des règles, et retrouvé par un nom dérivé du chemin plutôt que par un tableau associatif : le bash 3.2 livré avec macOS ne les connaît pas.