### PR TITLE
Mesurer : score de densité, hook pre-commit et CI

### DIFF
--- a/.github/workflows/eco-audit.yml
+++ b/.github/workflows/eco-audit.yml
@@ -1,0 +1,39 @@
+name: Éco-conception
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  tests:
+    name: Suite de tests de l'audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Installer jq
+        run: sudo apt-get install -y jq
+      - name: Valider le JSON des règles
+        run: jq empty skills/green-claude/rules/*.json skills/green-claude/rules/langages/*.json
+      - name: Lancer la suite de tests
+        run: bash skills/green-claude/scripts/test-eco-audit.sh
+
+  score:
+    name: Densité d'issues
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Installer jq
+        run: sudo apt-get install -y jq
+      # Informatif, jamais bloquant : un audit qui fait échouer la CI sur un
+      # candidat non confirmé apprend surtout à ignorer la CI.
+      - name: Mesurer la densité du dépôt
+        run: |
+          bash skills/green-claude/scripts/eco-score.sh | tee score.txt
+          {
+            echo '### Densité d'"'"'issues d'"'"'éco-conception'
+            echo ''
+            echo '```'
+            cat score.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/README.fr.md
+++ b/README.fr.md
@@ -152,6 +152,22 @@ eco-audit.sh --list-rules python    # checklist complète d'un langage
 
 ---
 
+## Mesurer, plutôt que supposer
+
+`eco-score.sh` compte les motifs détectés dans un dépôt, les pondère par impact et les rapporte au volume de code :
+
+```bash
+skills/green-claude/scripts/eco-score.sh          # lisible
+skills/green-claude/scripts/eco-score.sh --json   # une ligne par mesure, à historiser
+```
+
+Ce score compte des motifs connus, pas des joules. Une densité qui baisse dit que le code contient moins de motifs repérables, pas qu'il consomme moins. Comparez-la à celle du mois dernier plutôt qu'à zéro, et confrontez-la à une mesure d'exécution réelle (nombre de requêtes, octets transférés, temps CPU, EcoIndex sur une page) : c'est elle qui tranche.
+
+Deux autres points de contrôle, tous deux optionnels :
+
+- `hooks/green-claude-pre-commit.sh` audite les fichiers mis en index. Là où le hook Claude Code ne voit que ce que Claude écrit, celui-ci voit aussi ce que vous écrivez. Il signale sans bloquer, sauf si vous passez `GREEN_CLAUDE_STRICT=1`.
+- `.github/workflows/eco-audit.yml` fait tourner la suite de tests des règles sur chaque PR, et publie la densité du dépôt dans le résumé du job.
+
 ## Les pratiques Boris : utiliser Claude sobrement et avec bon sens
 
 Coder avec l'IA a aussi un coût pendant la session elle-même : chaque requête consomme de l'énergie. [Boris Cherny](https://howborisusesclaudecode.com/), créateur de Claude Code, documente des pratiques d'usage efficace. Un usage efficace est aussi un usage sobre : chaque aller-retour évité économise des tokens, chaque contexte allégé aussi.

--- a/README.md
+++ b/README.md
@@ -150,6 +150,22 @@ eco-audit.sh --list-rules python    # full checklist for one language
 
 ---
 
+## Measure, don't assume
+
+`eco-score.sh` counts the patterns found in a repository, weights them by impact and reports them against code volume:
+
+```bash
+skills/green-claude/scripts/eco-score.sh          # human-readable
+skills/green-claude/scripts/eco-score.sh --json   # one line per measurement, to keep over time
+```
+
+This score counts known patterns, not joules. A falling density says the code holds fewer recognizable patterns, not that it draws less power. Compare it to last month's rather than to zero, and check it against a real runtime measurement (query count, bytes transferred, CPU time, EcoIndex on a page): that's what settles it.
+
+Two more checkpoints, both optional:
+
+- `hooks/green-claude-pre-commit.sh` audits staged files. Where the Claude Code hook only sees what Claude writes, this one also sees what you write. It reports without blocking, unless you pass `GREEN_CLAUDE_STRICT=1`.
+- `.github/workflows/eco-audit.yml` runs the rule test suite on every PR and publishes the repository's density in the job summary.
+
 ## Boris's practices: using Claude soberly and sensibly
 
 Coding with AI also has a cost during the session itself: every request consumes energy. [Boris Cherny](https://howborisusesclaudecode.com/), Claude Code's creator, documents efficient usage practices. Efficient use is also sober use: every avoided back-and-forth saves tokens, every trimmed context does too.

--- a/hooks/green-claude-pre-commit.sh
+++ b/hooks/green-claude-pre-commit.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Hook git pre-commit : audite les fichiers de code mis en index avant qu'ils
+# n'entrent dans l'historique. Complète le hook PostToolUse de Claude Code, qui
+# ne voit que ce que Claude écrit — celui-ci voit aussi ce que tu écris toi.
+#
+# Installation :
+#   ln -s ../../hooks/green-claude-pre-commit.sh .git/hooks/pre-commit
+#
+# Ne bloque jamais le commit : il signale et laisse passer. Un audit qui empêche
+# de committer finit désactivé dans la semaine, et on perd les deux.
+# Pour bloquer volontairement : GREEN_CLAUDE_STRICT=1 git commit ...
+
+set -uo pipefail
+
+AUDIT="$HOME/.claude/skills/green-claude/scripts/eco-audit.sh"
+[ -x "$AUDIT" ] || AUDIT="$(git rev-parse --show-toplevel)/skills/green-claude/scripts/eco-audit.sh"
+[ -x "$AUDIT" ] || exit 0
+command -v jq >/dev/null 2>&1 || exit 0
+
+FILES=$(git diff --cached --name-only --diff-filter=ACM \
+        | grep -iE '\.(py|js|jsx|ts|tsx|mjs|cjs|sql|pks|pkb|prc|fnc|trg|java|cs|php|rb|rs|c|h|cpp|cc|cxx|hpp|hh|go|kt|swift|scala|html|htm|css|scss|sass|vue|svelte)$' || true)
+[ -n "$FILES" ] || exit 0
+
+REPORT=$(printf '%s\n' "$FILES" | tr '\n' '\0' | xargs -0 bash "$AUDIT" 2>/dev/null || true)
+grep -q '^\[' <<<"$REPORT" || exit 0
+
+echo "[Green Claude] Motifs d'éco-conception dans les fichiers commités :"
+echo ""
+echo "$REPORT"
+
+if [ "${GREEN_CLAUDE_STRICT:-0}" = "1" ]; then
+    echo "GREEN_CLAUDE_STRICT=1 : commit interrompu."
+    exit 1
+fi
+exit 0

--- a/skills/green-claude/scripts/eco-score.sh
+++ b/skills/green-claude/scripts/eco-score.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+# Densité d'issues d'éco-conception d'un dépôt, pour suivre l'évolution dans le
+# temps plutôt que de constater un chiffre isolé.
+#
+# Ce que ce score est : un compte de motifs détectables, pondéré par impact et
+# rapporté au volume de code. Ce qu'il n'est pas : une mesure d'énergie. Un
+# score qui baisse dit que le code contient moins de motifs connus, pas qu'il
+# consomme moins. Pour ça, il faut mesurer l'exécution réelle (requêtes SQL,
+# octets transférés, temps CPU, EcoIndex sur une page).
+#
+# Usage : eco-score.sh [chemin...]        (défaut : dépôt courant)
+#         eco-score.sh --json [chemin...] (une ligne JSON, pour l'historiser)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+AUDIT="$SCRIPT_DIR/eco-audit.sh"
+
+FORMAT="texte"
+if [ "${1:-}" = "--json" ]; then FORMAT="json"; shift; fi
+
+# Extensions auditables : celles que les règles savent lire. Inutile de compter
+# les Markdown et les JSON dans le volume, aucune règle ne s'y applique.
+EXTS='\.(py|js|jsx|ts|tsx|mjs|cjs|sql|pks|pkb|prc|fnc|trg|java|cs|php|rb|rs|c|h|cpp|cc|cxx|hpp|hh|go|kt|swift|scala|html|htm|css|scss|sass|vue|svelte)$'
+
+collect_files() {
+    if [ $# -eq 0 ]; then
+        # Dans un dépôt git : les fichiers suivis, donc ni node_modules ni
+        # artefacts de build, sans avoir à maintenir une liste d'exclusions.
+        if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+            git ls-files | grep -iE "$EXTS" || true
+        else
+            find . -type f | grep -iE "$EXTS" || true
+        fi
+    else
+        for path in "$@"; do
+            if [ -d "$path" ]; then
+                find "$path" -type f | grep -iE "$EXTS" || true
+            elif [ -f "$path" ]; then
+                printf '%s\n' "$path" | grep -iE "$EXTS" || true
+            fi
+        done
+    fi
+}
+
+FILES="$(collect_files "$@")"
+if [ -z "$FILES" ]; then
+    echo "Aucun fichier auditable trouvé." >&2
+    exit 1
+fi
+
+nb_files=$(printf '%s\n' "$FILES" | wc -l | tr -d ' ')
+nb_lines=$(printf '%s\n' "$FILES" | tr '\n' '\0' | xargs -0 cat 2>/dev/null | wc -l | tr -d ' ')
+
+REPORT="$(printf '%s\n' "$FILES" | tr '\n' '\0' | xargs -0 bash "$AUDIT" 2>/dev/null || true)"
+eleve=$(printf '%s\n' "$REPORT" | grep -c '^\[Élevé\]' || true)
+moyen=$(printf '%s\n' "$REPORT" | grep -c '^\[Moyen\]' || true)
+faible=$(printf '%s\n' "$REPORT" | grep -c '^\[Faible\]' || true)
+
+# Pondération : un défaut à impact élevé pèse trois fois un défaut faible. Les
+# poids sont arbitraires et assumés comme tels ; ce qui compte est de garder
+# les mêmes d'une mesure à l'autre pour que la comparaison ait un sens.
+poids=$(( eleve * 3 + moyen * 2 + faible ))
+if [ "$nb_lines" -gt 0 ]; then
+    densite=$(LC_ALL=C awk -v p="$poids" -v l="$nb_lines" 'BEGIN { printf "%.2f", p * 1000 / l }')
+else
+    densite="0.00"
+fi
+
+if [ "$FORMAT" = "json" ]; then
+    printf '{"date":"%s","fichiers":%d,"lignes":%d,"eleve":%d,"moyen":%d,"faible":%d,"poids":%d,"densite_pour_1000_lignes":%s}\n' \
+        "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$nb_files" "$nb_lines" "$eleve" "$moyen" "$faible" "$poids" "$densite"
+    exit 0
+fi
+
+echo "Score d'éco-conception"
+echo "  Fichiers audités : $nb_files ($nb_lines lignes)"
+echo "  Impact Élevé     : $eleve"
+echo "  Impact Moyen     : $moyen"
+echo "  Impact Faible    : $faible"
+echo "  Poids total      : $poids (Élevé×3 + Moyen×2 + Faible×1)"
+echo "  Densité          : $densite pour 1000 lignes"
+echo ""
+echo "Comparez cette densité à celle d'hier, pas à zéro : c'est la tendance qui"
+echo "renseigne. Et confrontez-la à une mesure d'exécution réelle (requêtes,"
+echo "octets transférés, EcoIndex), seule capable de dire si la consommation baisse."


### PR DESCRIPTION
## Pourquoi

Le dépôt sait détecter des motifs, mais rien ne dit encore si les règles servent à quelque chose ni si elles sont appliquées. Trois outils, du plus léger au plus contraignant.

## `eco-score.sh`

Compte les motifs d'un dépôt, les pondère par impact (Élevé×3, Moyen×2, Faible×1) et les rapporte à 1000 lignes.

```bash
skills/green-claude/scripts/eco-score.sh          # lisible
skills/green-claude/scripts/eco-score.sh --json   # une ligne par mesure, à historiser
```

Les fichiers viennent de `git ls-files` quand on est dans un dépôt : ni `node_modules` ni artefacts de build, sans liste d'exclusions à maintenir.

**Ce que le score n'est pas**, et le README le dit noir sur blanc : une mesure d'énergie. Il compte des motifs connus. Une densité qui baisse dit que le code en contient moins, pas qu'il consomme moins. Seule une mesure d'exécution (requêtes SQL, octets transférés, temps CPU, EcoIndex) peut trancher. Les poids sont arbitraires et assumés comme tels ; ce qui compte est de garder les mêmes d'une mesure à l'autre.

## `hooks/green-claude-pre-commit.sh`

Audite les fichiers mis en index. Le hook `PostToolUse` ne voit que ce que Claude écrit ; celui-ci voit aussi ce que l'humain écrit.

Il signale sans bloquer. Un audit qui empêche de committer finit désactivé dans la semaine, et on perd les deux. `GREEN_CLAUDE_STRICT=1` pour bloquer volontairement.

## `.github/workflows/eco-audit.yml`

Valide le JSON de toutes les règles, fait tourner les 29 vérifications sur chaque PR, et publie la densité du dépôt dans le résumé du job. Le score est informatif et ne fait jamais échouer la CI : un hit reste un candidat, et faire échouer une CI sur un candidat apprend surtout à ignorer la CI.

C'est la première CI du dépôt, donc à surveiller au premier passage.

## Défaut repéré au passage, non traité ici

Les détecteurs awk (`detect-dead-code`, `detect-implicit-globals`) tournent sur tous les fichiers sans filtre d'extension. Écrits pour JavaScript, ils se déclenchent sur `eco-audit.sh` lui-même : `esac` pris pour du code mort, `SCRIPT_DIR=` pour une globale implicite. Antérieur à cette PR, à traiter séparément en ajoutant un périmètre d'extensions aux règles à détecteur.