### PR TITLE
Borner les détecteurs awk au langage pour lequel ils sont écrits

### DIFF
--- a/skills/green-claude/rules/ecoconception.json
+++ b/skills/green-claude/rules/ecoconception.json
@@ -419,6 +419,15 @@
             "css",
             "animation",
             "accessibilite"
+          ],
+          "extensions": [
+            "css",
+            "scss",
+            "sass",
+            "html",
+            "htm",
+            "vue",
+            "svelte"
           ]
         }
       ]
@@ -550,6 +559,29 @@
             "code-mort",
             "javascript",
             "maintenance"
+          ],
+          "extensions": [
+            "js",
+            "jsx",
+            "ts",
+            "tsx",
+            "mjs",
+            "cjs",
+            "java",
+            "cs",
+            "php",
+            "go",
+            "rs",
+            "swift",
+            "kt",
+            "scala",
+            "c",
+            "h",
+            "cpp",
+            "cc",
+            "cxx",
+            "hpp",
+            "hh"
           ]
         },
         {
@@ -567,6 +599,18 @@
             "javascript",
             "portee",
             "maintenance"
+          ],
+          "extensions": [
+            "js",
+            "jsx",
+            "ts",
+            "tsx",
+            "mjs",
+            "cjs",
+            "vue",
+            "svelte",
+            "html",
+            "htm"
           ]
         },
         {
@@ -602,6 +646,12 @@
             "dom",
             "html",
             "complexite"
+          ],
+          "extensions": [
+            "html",
+            "htm",
+            "vue",
+            "svelte"
           ]
         },
         {
@@ -619,6 +669,12 @@
             "dom",
             "html",
             "accessibilite"
+          ],
+          "extensions": [
+            "html",
+            "htm",
+            "vue",
+            "svelte"
           ]
         },
         {
@@ -636,6 +692,15 @@
             "css",
             "specificite",
             "maintenance"
+          ],
+          "extensions": [
+            "css",
+            "scss",
+            "sass",
+            "vue",
+            "svelte",
+            "html",
+            "htm"
           ]
         },
         {
@@ -654,6 +719,11 @@
             "css",
             "code-mort",
             "maintenance"
+          ],
+          "extensions": [
+            "css",
+            "scss",
+            "sass"
           ]
         },
         {
@@ -691,6 +761,12 @@
             "javascript",
             "chargement",
             "performance"
+          ],
+          "extensions": [
+            "html",
+            "htm",
+            "vue",
+            "svelte"
           ]
         }
       ]
@@ -752,6 +828,31 @@
             "algorithmes",
             "complexite",
             "cpu"
+          ],
+          "extensions": [
+            "js",
+            "jsx",
+            "ts",
+            "tsx",
+            "mjs",
+            "cjs",
+            "py",
+            "java",
+            "cs",
+            "php",
+            "rb",
+            "go",
+            "rs",
+            "kt",
+            "swift",
+            "scala",
+            "c",
+            "h",
+            "cpp",
+            "cc",
+            "cxx",
+            "hpp",
+            "hh"
           ]
         },
         {
@@ -835,6 +936,22 @@
             "https",
             "tls",
             "securite"
+          ],
+          "extensions": [
+            "html",
+            "htm",
+            "vue",
+            "svelte",
+            "css",
+            "scss",
+            "sass",
+            "js",
+            "jsx",
+            "ts",
+            "tsx",
+            "mjs",
+            "cjs",
+            "md"
           ]
         },
         {
@@ -877,6 +994,15 @@
             "liens",
             "404",
             "maintenance"
+          ],
+          "extensions": [
+            "html",
+            "htm",
+            "vue",
+            "svelte",
+            "css",
+            "scss",
+            "sass"
           ]
         }
       ]

--- a/skills/green-claude/scripts/eco-audit.sh
+++ b/skills/green-claude/scripts/eco-audit.sh
@@ -220,7 +220,11 @@ while IFS= read -r rule_json; do
     rgesn_ref=$(jq -r '.rgesn_ref' <<<"$rule_json")
     note=$(jq -r '.note // .detector_note // .enrich_note // ""' <<<"$rule_json")
 
-    exts=$(jq -r '(.exts // []) | join(" ")' <<<"$rule_json")
+    # `exts` vient des règles de langage (rules/langages/), `extensions` du
+    # périmètre déclaré par une règle transverse — un détecteur écrit pour du
+    # JavaScript n'a rien à dire sur un script shell, où `esac` ressemble à du
+    # code mort et `VAR=` à une globale implicite.
+    exts=$(jq -r '((.exts // []) + (.extensions // [])) | join(" ")' <<<"$rule_json")
 
     for file in "$@"; do
         [ -f "$file" ] || continue

--- a/skills/green-claude/scripts/test-eco-audit.sh
+++ b/skills/green-claude/scripts/test-eco-audit.sh
@@ -455,4 +455,31 @@ OUT="$(bash eco-audit.sh "$TMP/vue-francaise.js")"
 echo "$OUT" | grep -q 'ECO-ARCH-01' && fail "faux positif : framework signalé sans import ni dépendance"
 true
 
-echo "OK - 29 verifications passees"
+# 30. Périmètre des détecteurs : les awk sont écrits pour un langage donné et
+# ne doivent pas parler des autres. Sur un script shell, `esac` ressemble à du
+# code mort et `VAR=` à une variable globale implicite.
+cat > "$TMP/script.sh" <<'EOF'
+#!/bin/bash
+SCRIPT_DIR="$(dirname "$0")"
+case "$1" in
+    a) echo un ;;
+esac
+EOF
+OUT="$(bash eco-audit.sh "$TMP/script.sh")"
+echo "$OUT" | grep -q 'ECO-FRONT-05' && fail "faux positif : détecteur de code mort JS lancé sur du shell"
+echo "$OUT" | grep -q 'ECO-FRONT-06' && fail "faux positif : détecteur de globales JS lancé sur du shell"
+true
+
+# Et le détecteur reste actif là où il a un sens.
+cat > "$TMP/reel.js" <<'EOF'
+var fuite = 1;
+function f() {
+  return 1;
+  console.log("mort");
+}
+EOF
+OUT="$(bash eco-audit.sh "$TMP/reel.js")"
+echo "$OUT" | grep -q 'ECO-FRONT-05' || fail "code mort JS non détecté après ajout du périmètre"
+echo "$OUT" | grep -q 'ECO-FRONT-06' || fail "globale implicite JS non détectée après ajout du périmètre"
+
+echo "OK - 30 verifications passees"


### PR DESCRIPTION
Quatrième faux positif, signalé dans la description de #30 et corrigé ici.

## Le problème

Les onze règles à détecteur lancent leur awk sur tous les fichiers passés en argument, sans regarder de quel langage il s'agit. `detect-dead-code.awk` et `detect-implicit-globals.awk` sont écrits pour JavaScript et se déclenchaient sur `eco-audit.sh` lui-même :

```
[Faible] ECO-FRONT-05 — Pas de code mort
  Ligne : 107:    esac
[Faible] ECO-FRONT-06 — Éviter les variables globales implicites
  Ligne : 10:SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
```

`esac` ferme un `case` shell, `SCRIPT_DIR=` est une affectation shell parfaitement normale. Aucun des deux n'est un défaut.

## La correction

Chaque règle à détecteur déclare son périmètre dans un champ `extensions`, qui réutilise le filtre déjà en place pour les règles de langage. Aucune nouvelle mécanique.

| Détecteur | Périmètre |
|---|---|
| `dom_size`, `duplicate_ids`, `blocking_scripts` | balisage |
| `css_duplicates`, `css_importants`, `reduced_motion` | feuilles de style et balisage |
| `dead_code` | langages à accolades |
| `nested_loops` | langages à accolades et Python |
| `implicit_globals` | JS/TS et pages qui embarquent du script |
| `insecure_links`, `broken_links` | balisage, styles, scripts |

## Tests

De 29 à 30 vérifications, dans les deux sens : silence sur un script shell dont le `case`/`esac` et les affectations ressemblent à du JavaScript mal écrit, détection maintenue sur du vrai JavaScript (code mort après `return`, `var` au niveau racine).

Vérifié aussi que `eco-audit.sh` ne se signale plus lui-même.