### PR TITLE
SKILL.md en anglais, déclencheurs français conservés

### DIFF
--- a/skills/green-claude/SKILL.md
+++ b/skills/green-claude/SKILL.md
@@ -1,12 +1,13 @@
 ---
 name: green-claude
 description: |
-  Use when Claude écrit, modifie ou revoit du code (formats de fichiers, requêtes
-  réseau, images/assets, boucles, cache, pagination, dépendances, choix de
-  framework ou de modèle IA), quand l'utilisateur demande un audit de sobriété
-  ("audit éco-conception", "vérifie la sobriété de ce code", "--eco-check",
-  "RGESN", "GR491", "écoconception", "green IT"), ou quand invoqué via
-  /green-claude pour parcourir la checklist des règles.
+  Use when Claude writes, modifies or reviews code (file formats, network
+  requests, images/assets, loops, caching, pagination, dependencies, framework
+  or AI model choice), when the user asks for a sobriety audit ("eco-design
+  audit", "check this code for sobriety", "--eco-check", "RGESN", "GR491",
+  "eco-design", "green IT", "audit éco-conception", "vérifie la sobriété de ce
+  code", "écoconception"), or when invoked via /green-claude to walk through the
+  rule checklist.
 author: Institut du Numérique Responsable
 version: 1.3.0
 license: MIT
@@ -15,93 +16,92 @@ user-invocable: true
 
 # Green Claude
 
-Trois jeux de règles : `rules/ecoconception.json` (52 règles, RGESN 2024 / GR491 /
-Green Software Foundation) pendant que tu écris ou modifies du code,
-`rules/langages/*.json` (80 règles) pour le langage sur lequel tu travailles, et
-`rules/boris.json` (14 pratiques d'usage) pendant la conversation elle-même. Un
-usage efficace de Claude Code est aussi un usage sobre.
+Three rule sets: `rules/ecoconception.json` (52 rules, RGESN 2024 / GR491 /
+Green Software Foundation) while you write or modify code,
+`rules/langages/*.json` (80 rules) for the language you're working in, and
+`rules/boris.json` (14 usage practices) during the conversation itself. Using
+Claude Code efficiently is also using it soberly.
 
-## Référence rapide
+## Quick reference
 
-| Mode | Déclencheur | Action |
+| Mode | Trigger | Action |
 |---|---|---|
-| Proactif (par défaut) | Toujours, dès que tu écris ou modifies du code | Applique les familles pertinentes de `ecoconception.json`, sans qu'on te le demande |
-| Audit | « audit éco-conception », « vérifie la sobriété », `--eco-check` | `bash <chemin-du-skill>/scripts/eco-audit.sh fichier1 fichier2 ...` |
-| Browse | `/green-claude` | Checklist complète des 9 familles RGESN + 14 pratiques Boris |
+| Proactive (default) | Always, as soon as you write or modify code | Apply the relevant families from `ecoconception.json`, unprompted |
+| Audit | "eco-design audit", "check the sobriety", `--eco-check` | `bash <skill-path>/scripts/eco-audit.sh file1 file2 ...` |
+| Browse | `/green-claude` | Full checklist of the 9 RGESN families + 14 Boris practices |
 
-## Mode proactif
+## Proactive mode
 
-Garde en tête les 9 familles de `ecoconception.json` (stratégie, spécifications,
-architecture, UX, contenus, frontend, backend, hébergement, algorithmie).
-Concrètement, sans qu'on te le demande :
+Keep the 9 families of `ecoconception.json` in mind (strategy, specifications,
+architecture, UX, content, frontend, backend, hosting, algorithms). Concretely,
+without being asked:
 
-- Préfère les formats ouverts et légers (JSON/CSV/Markdown plutôt que docx/xlsx).
-- Limite les requêtes réseau et les payloads (pagination, champs sélectionnés, pas de `SELECT *`).
-- Évite les boucles ou traitements redondants, mets en cache ce qui est stable.
-- Ne charge/n'importe que ce qui est utilisé (pas de librairie entière pour une fonction).
-- Compresse et dimensionne correctement les images et assets.
+- Prefer open, lightweight formats (JSON/CSV/Markdown over docx/xlsx).
+- Limit network requests and payloads (pagination, selected fields, no `SELECT *`).
+- Avoid redundant loops and processing, cache what is stable.
+- Load and import only what is used (no whole library for one function).
+- Compress and correctly size images and assets.
 
-Si une contrainte de sobriété entre en tension avec une demande explicite du user
-(perf, deadline, lisibilité), signale le compromis en une phrase, sans jamais
-bloquer silencieusement le travail demandé.
+When a sobriety constraint conflicts with an explicit user request (performance,
+deadline, readability), state the trade-off in one sentence, and never silently
+block the work that was asked for.
 
-Pour la conversation, applique ce qui dépend de toi parmi les réflexes Boris :
-garde le contexte minimal, ne précharge pas des fichiers entiers si tu peux les
-lire toi-même à la demande. Si une correction en cascade s'annonce, suggère
-plutôt à l'utilisateur de rembobiner (double Échap) : c'est son geste, pas le
-tien, mais le lui rappeler évite d'empiler les tentatives ratées dans le contexte.
+For the conversation itself, apply whatever is up to you among the Boris
+reflexes: keep the context minimal, don't preload entire files when you can read
+them yourself on demand. If a cascade of corrections is building up, suggest the
+user rewind (double Esc) instead: it's their move, not yours, but raising it
+avoids stacking failed attempts in the context.
 
-## Mode audit
+## Audit mode
 
-`bash <chemin-du-skill>/scripts/eco-audit.sh fichier1 fichier2 ...` : un script déterministe
-(grep/awk), sans coût de raisonnement pour la détection. Interprète et priorise
-la sortie (impact Élevé d'abord) — voir *Erreurs courantes* avant de relayer un
-résultat tel quel.
+`bash <skill-path>/scripts/eco-audit.sh file1 file2 ...` is a deterministic
+script (grep/awk) with no reasoning cost for detection. Interpret and prioritize
+its output (High impact first), and read *Common mistakes* below before relaying
+a result as-is.
 
-Les règles sans pattern détectable (« mesurer avant d'optimiser », « critères
-environnementaux dans les user stories »...) sont des règles de démarche,
-listées via `<chemin-du-skill>/scripts/eco-audit.sh --list-rules` plutôt que cherchées par grep.
+Rules with no detectable pattern ("measure before optimizing", "environmental
+criteria in user stories"...) are process rules, listed via
+`<skill-path>/scripts/eco-audit.sh --list-rules` rather than searched by grep.
 
-## Règles propres à un langage
+## Language-specific rules
 
-`rules/langages/` contient un fichier par langage (Python, JS/TS, SQL, Java, C#,
-PHP, Ruby, Rust, C, C++) : les idiomes que les règles transverses ne peuvent pas
-nommer, comme le N+1 d'un ORM, la pagination par curseur, `parallelStream()` ou
-`clone()` de confort. Ne consulte que le fichier du langage sur lequel tu
-travailles, jamais les dix : l'audit fait déjà cette sélection à partir de
-l'extension du fichier, et n'applique jamais un motif Python à du Java.
+`rules/langages/` holds one file per language (Python, JS/TS, SQL, Java, C#, PHP,
+Ruby, Rust, C, C++): the idioms cross-cutting rules cannot name, such as ORM
+N+1 queries, cursor-based pagination, `parallelStream()` or convenience
+`clone()`. Only consult the file for the language you're working in, never all
+ten: the audit already makes that selection from the file extension, and never
+applies a Python pattern to Java.
 
-`eco-audit.sh --list-langs` liste les langages couverts, `--list-rules <langage>`
-sort la checklist complète d'un langage.
+`eco-audit.sh --list-langs` lists the covered languages, `--list-rules <language>`
+prints the full checklist for one of them.
 
-## Mode browse (`/green-claude`)
+## Browse mode (`/green-claude`)
 
-Checklist des 9 familles RGESN et des 14 pratiques Boris, avec titre et
-recommandation de chaque règle. Utile pour une revue de conception en amont du code.
+Checklist of the 9 RGESN families and the 14 Boris practices, with each rule's
+title and recommendation. Useful for a design review before any code is written.
 
-## Erreurs courantes
+## Common mistakes
 
-Un hit du script d'audit est un **candidat**, pas une violation confirmée. Quand
-une ligne `Note` accompagne un résultat, lis-la avant de relayer quoi que ce
-soit à l'utilisateur : elle explique la limite précise du pattern ou du
-détecteur pour cette règle (faux positif connu, seuil, portée...) — c'est
-l'information à jour, plutôt qu'une liste séparée ici qui se périmerait à
-chaque nouvelle règle.
+A hit from the audit script is a **candidate**, not a confirmed violation. When a
+`Note` line comes with a result, read it before relaying anything to the user: it
+explains the precise limit of that rule's pattern or detector (known false
+positive, threshold, scope). It lives in the rule itself, so it stays current,
+unlike a separate list here that would go stale with every new rule.
 
-## Garantie d'application
+## Guaranteed application
 
-Charger ce skill reste une décision du modèle : ça arrive souvent, pas à tous les
-coups. Pour une vérification qui ne dépende de personne, le dépôt fournit
-`hooks/green-claude-audit.sh`, câblé en `PostToolUse` sur `Write|Edit|MultiEdit`.
-Claude Code l'exécute après chaque écriture de fichier de code et te renvoie les
-motifs trouvés. N'audite que le contenu ajouté par l'écriture, et reste muet
-quand il ne trouve rien.
+Loading this skill remains the model's decision: it happens often, not every
+time. For a check that depends on no one, the repository ships
+`hooks/green-claude-audit.sh`, wired as `PostToolUse` on `Write|Edit|MultiEdit`.
+Claude Code runs it after every code file written and hands you back the patterns
+it found. It only audits what the write added, and stays silent when it finds
+nothing.
 
-## Ce que ce skill ne fait PAS
+## What this skill does NOT do
 
-Le cache de réponses « zéro token » ne peut pas être géré par un skill : il doit
-être câblé via des hooks `UserPromptSubmit`/`Stop`, qui interceptent la requête
-*avant* qu'elle n'atteigne le modèle (voir `hooks/` à la racine du dépôt). Le
-choix du modèle (Haiku/Sonnet/Opus), lui, peut être changé en cours de session
-via `/model` : ce skill ne le fait pas à ta place, mais rien n'empêche de
-suggérer un modèle plus léger si une tâche y est manifestement disproportionnée.
+The "zero token" response cache cannot be handled by a skill: it has to be wired
+through `UserPromptSubmit`/`Stop` hooks, which intercept the request *before* it
+reaches the model (see `hooks/` at the repository root). The model choice
+(Haiku/Sonnet/Opus) can be changed mid-session with `/model`: this skill won't do
+it for you, but nothing stops you from suggesting a lighter model when a task is
+plainly out of proportion with it.


### PR DESCRIPTION
## Pourquoi

Le README est passé en anglais avec #23, `README.fr.md` gardant la version française. `SKILL.md` était resté en français, et sa `description` mélangeait les deux langues :

```yaml
description: Use when Claude écrit, modifie ou revoit du code (formats de fichiers...)
```

C'est le fichier que lit Claude, et c'est aussi le premier qu'ouvre quelqu'un qui découvre le projet depuis un annuaire international. Le laisser en français ferme la porte au public que le README anglais cherche justement à atteindre.

## Ce qui change

Le corps passe en anglais. Rien d'autre : ni les identifiants de règles, ni les références RGESN/GR491, ni les chemins de scripts.

## Ce qui ne change pas, volontairement

La `description` conserve les déclencheurs français à côté des anglais :

```yaml
"eco-design audit", "check this code for sobriety", "--eco-check", "RGESN",
"GR491", "eco-design", "green IT", "audit éco-conception",
"vérifie la sobriété de ce code", "écoconception"
```

Ce sont ces chaînes qui font charger le skill quand la demande est formulée en français. Les retirer casserait l'usage de tous les utilisateurs actuels, qui sont francophones.

## Vérifications

Frontmatter YAML valide, tous les chemins cités existent, aucun résidu français dans le corps, et les 30 vérifications de `test-eco-audit.sh` passent (le comportement du script ne dépend pas de ce fichier, mais autant le confirmer).