### PR TITLE
Rendre le skill installable dans Claude.ai et via l'API Skills

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ node_modules/
 
 # Secrets locaux
 .env
+
+# Archives générées par scripts/package-skill.sh
+dist/

--- a/README.fr.md
+++ b/README.fr.md
@@ -104,6 +104,33 @@ En pratique, tu n'as pas besoin de lancer l'audit toi-même sur ce genre de code
 
 ---
 
+## Installer nativement dans Claude
+
+Trois canaux, trois formats. Claude Code n'a besoin de rien d'autre que le dépôt :
+
+```bash
+/plugin marketplace add Institut-du-Numerique-Responsable/green-claude
+/plugin install green-claude
+```
+
+Les deux autres attendent une archive zip, que `package-skill.sh` fabrique :
+
+```bash
+bash skills/green-claude/scripts/package-skill.sh    # écrit dans dist/
+```
+
+| Canal | Archive | Installation |
+|---|---|---|
+| Claude Code | aucune | la commande ci-dessus, ou `npx skills add Institut-du-Numerique-Responsable/green-claude` |
+| Claude.ai | `dist/green-claude-claude-ai.zip` | Réglages → Fonctionnalités → Skills → Téléverser (l'exécution de code doit être activée) |
+| API Claude | `dist/green-claude-api.zip` | `client.beta.skills.create(files=files_from_dir("green-claude"))` |
+
+Les deux archives contiennent le même skill et ne diffèrent que par la description : Claude.ai la plafonne à 200 caractères là où l'API en autorise 1024. Le dépôt garde la longue, celle qui fait charger le skill au bon moment dans Claude Code ; le script d'empaquetage lui substitue une version courte plutôt que de tronquer en plein milieu, une phrase coupée se déclenchant mal.
+
+Le script d'audit a besoin de `bash` et de `jq`. Là où `jq` manque, les règles continuent de s'appliquer pendant que Claude écrit du code : seul `eco-audit.sh` cesse de fonctionner.
+
+---
+
 ## Les règles : 52 règles alignées sur les 9 familles du RGESN 2024
 
 [`skills/green-claude/rules/ecoconception.json`](skills/green-claude/rules/ecoconception.json) couvre les **9 familles** du [RGESN 2024](https://www.arcep.fr/mes-demarches-et-services/entreprises/fiches-pratiques/referentiel-general-ecoconception-services-numeriques.html) (78 critères officiels). Chaque règle référence le critère RGESN correspondant (`rgesn_ref`) et la famille [GR491](https://gr491.isit-europe.org/) (`gr491_famille`) :

--- a/README.md
+++ b/README.md
@@ -102,6 +102,33 @@ In practice, you don't need to run the audit yourself on code like this: in proa
 
 ---
 
+## Installing natively in Claude
+
+Three channels, three formats. Claude Code needs nothing more than the repository:
+
+```bash
+/plugin marketplace add Institut-du-Numerique-Responsable/green-claude
+/plugin install green-claude
+```
+
+The other two want a zip archive, which `package-skill.sh` builds:
+
+```bash
+bash skills/green-claude/scripts/package-skill.sh    # writes into dist/
+```
+
+| Channel | Archive | How to install |
+|---|---|---|
+| Claude Code | none | `/plugin marketplace add …` above, or `npx skills add Institut-du-Numerique-Responsable/green-claude` |
+| Claude.ai | `dist/green-claude-claude-ai.zip` | Settings → Capabilities → Skills → Upload skill (code execution must be enabled) |
+| Claude API | `dist/green-claude-api.zip` | `client.beta.skills.create(files=files_from_dir("green-claude"))` |
+
+The two archives hold the same skill and differ only by the description: Claude.ai caps it at 200 characters where the API allows 1024. The repository keeps the long one, which is what makes Claude Code load the skill at the right moment; the packaging script substitutes a short version rather than truncating mid-sentence, since a sentence cut in half triggers badly.
+
+The audit script needs `bash` and `jq`. Where `jq` is missing, the rules still apply while Claude writes code — only `eco-audit.sh` stops working.
+
+---
+
 ## The rules: 52 rules aligned with the 9 RGESN 2024 families
 
 [`skills/green-claude/rules/ecoconception.json`](skills/green-claude/rules/ecoconception.json) covers all **9 families** of [RGESN 2024](https://www.arcep.fr/mes-demarches-et-services/entreprises/fiches-pratiques/referentiel-general-ecoconception-services-numeriques.html) (78 official criteria). Each rule references the matching RGESN criterion (`rgesn_ref`) and [GR491](https://gr491.isit-europe.org/) family (`gr491_famille`):

--- a/skills/green-claude/scripts/package-skill.sh
+++ b/skills/green-claude/scripts/package-skill.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# Fabrique l'archive installable du skill, pour les canaux qui attendent un zip
+# plutôt qu'un dépôt git : l'API Skills et l'upload dans Claude.ai.
+#
+# Claude Code, lui, n'a besoin de rien de tout ça : le dépôt est un marketplace
+# de plugins, installable par /plugin marketplace add.
+#
+# Usage : package-skill.sh [dossier-de-sortie]   (défaut : dist/)
+#
+# Les deux cibles n'ont pas les mêmes limites de description (1024 caractères
+# pour l'API, 200 pour l'upload Claude.ai). Le dépôt garde la description
+# longue, qui sert au déclenchement dans Claude Code ; l'archive Claude.ai
+# reçoit une version courte, déclarée ici plutôt que tronquée au caractère près
+# — une phrase coupée en plein milieu déclenche mal.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+OUT_DIR="${1:-$(cd "$SKILL_DIR/../.." && pwd)/dist}"
+
+DESCRIPTION_COURTE="Eco-design rules (RGESN 2024, GR491) applied while writing or reviewing code, plus a deterministic sobriety audit. Ask for an \"eco-design audit\" or \"audit éco-conception\"."
+
+command -v zip >/dev/null 2>&1 || { echo "zip est requis." >&2; exit 1; }
+
+mkdir -p "$OUT_DIR"
+BUILD="$(mktemp -d)"
+trap 'rm -rf "$BUILD"' EXIT
+
+# Le dossier à la racine de l'archive doit porter le nom du skill : c'est ce
+# que vérifient l'API comme l'upload Claude.ai.
+cp -r "$SKILL_DIR" "$BUILD/green-claude"
+rm -rf "$BUILD/green-claude/scripts/test-eco-audit.sh" "$BUILD/green-claude/scripts/package-skill.sh"
+
+verifie_limites() { # $1 = fichier SKILL.md, $2 = limite de description
+    local fichier="$1" limite="$2" desc n
+    desc=$(awk '/^description: \|/{flag=1; next} /^[a-z_-]+:/{flag=0} flag' "$fichier" \
+           || true)
+    [ -n "$desc" ] || desc=$(awk -F'description: ' '/^description: /{print $2}' "$fichier")
+    n=$(printf '%s' "$desc" | tr -d '\n ' | wc -c | tr -d ' ')
+    if [ "$n" -gt "$limite" ]; then
+        echo "  description : $n caractères, au-delà de la limite de $limite" >&2
+        return 1
+    fi
+    echo "  description : $n caractères (limite $limite)"
+}
+
+echo "Archive API Skills (limite de description : 1024)"
+verifie_limites "$BUILD/green-claude/SKILL.md" 1024
+(cd "$BUILD" && zip -qr "$OUT_DIR/green-claude-api.zip" green-claude)
+echo "  -> $OUT_DIR/green-claude-api.zip"
+
+# Variante Claude.ai : même contenu, description courte.
+python3 - "$BUILD/green-claude/SKILL.md" "$DESCRIPTION_COURTE" <<'PY'
+import re, sys, pathlib
+chemin, courte = pathlib.Path(sys.argv[1]), sys.argv[2]
+texte = chemin.read_text()
+texte = re.sub(r"^description: \|\n(?:  .*\n)+", f"description: {courte}\n", texte, count=1, flags=re.M)
+chemin.write_text(texte)
+PY
+
+echo "Archive Claude.ai (limite de description : 200)"
+verifie_limites "$BUILD/green-claude/SKILL.md" 200
+(cd "$BUILD" && zip -qr "$OUT_DIR/green-claude-claude-ai.zip" green-claude)
+echo "  -> $OUT_DIR/green-claude-claude-ai.zip"

--- a/skills/green-claude/scripts/test-eco-audit.sh
+++ b/skills/green-claude/scripts/test-eco-audit.sh
@@ -482,4 +482,25 @@ OUT="$(bash eco-audit.sh "$TMP/reel.js")"
 echo "$OUT" | grep -q 'ECO-FRONT-05' || fail "code mort JS non détecté après ajout du périmètre"
 echo "$OUT" | grep -q 'ECO-FRONT-06' || fail "globale implicite JS non détectée après ajout du périmètre"
 
-echo "OK - 30 verifications passees"
+# 31. Empaquetage : les deux canaux qui attendent un zip (API Skills, upload
+# Claude.ai) exigent un dossier unique à la racine, nommé comme le skill, et
+# une description sous leur limite respective — 1024 et 200 caractères.
+if command -v zip >/dev/null 2>&1; then
+    DIST="$TMP/dist"
+    bash package-skill.sh "$DIST" >/dev/null 2>&1 || fail "package-skill.sh a échoué"
+    [ -f "$DIST/green-claude-api.zip" ] || fail "archive API absente"
+    [ -f "$DIST/green-claude-claude-ai.zip" ] || fail "archive Claude.ai absente"
+
+    RACINES=$(unzip -l "$DIST/green-claude-api.zip" | awk 'NR>3 && $4 != "" {split($4,a,"/"); print a[1]}' | sort -u | grep -v '^-' || true)
+    [ "$RACINES" = "green-claude" ] || fail "l'archive doit contenir un seul dossier racine nommé green-claude (trouvé : $RACINES)"
+
+    DESC=$(unzip -p "$DIST/green-claude-claude-ai.zip" green-claude/SKILL.md | awk -F'description: ' '/^description: /{print $2}')
+    N=$(printf '%s' "$DESC" | wc -c | tr -d ' ')
+    [ "$N" -le 200 ] || fail "description de la variante Claude.ai : $N caractères, limite 200"
+    [ "$N" -gt 0 ] || fail "description absente de la variante Claude.ai"
+
+    unzip -p "$DIST/green-claude-api.zip" green-claude/rules/langages/python.json >/dev/null 2>&1 \
+        || fail "les règles par langage manquent dans l'archive"
+fi
+
+echo "OK - 31 verifications passees"


### PR DESCRIPTION
## Ce qui manquait

Le dépôt est un marketplace de plugins, donc Claude Code sait déjà l'installer. Les deux autres canaux, eux, attendent une archive zip et refusent le dépôt tel quel :

| Canal | Format attendu | Limite de `description` | État avant cette PR |
|---|---|---|---|
| Claude Code | dépôt git | aucune | déjà natif |
| API Skills | zip, dossier racine unique nommé comme le skill | 1024 caractères | pas d'archive |
| Claude.ai | zip, idem | **200 caractères** | pas d'archive, et description trop longue |

Notre description fait 410 caractères : bonne pour l'API, refusée par Claude.ai.

## `package-skill.sh`

Produit les deux archives dans `dist/` et vérifie les limites de chacune.

Les deux contiennent le même skill. Seule la description change. Le dépôt garde la longue, celle qui contient les déclencheurs français et anglais et qui fait charger le skill au bon moment dans Claude Code. La variante Claude.ai reçoit une version courte **écrite à la main**, pas une troncature à 200 caractères : une phrase coupée en plein milieu déclenche mal, et c'est précisément ce champ qui décide du chargement.

## Tests

31 vérifications au lieu de 30. La nouvelle contrôle ce que les deux plateformes refusent : dossier racine unique et correctement nommé, description sous la limite de chaque cible, et présence des règles par langage dans l'archive. Sautée si `zip` n'est pas installé.

Vérifié à la main aussi : archive de 65 Ko (limite 30 Mo), et le skill extrait de l'archive détecte bien un `SELECT *`.

## Une limite dite explicitement

`eco-audit.sh` a besoin de `bash` et de `jq`. Je n'ai pas pu vérifier la présence de `jq` dans le conteneur d'exécution de Claude.ai. Les README l'annoncent donc franchement : sans `jq`, les règles continuent de s'appliquer pendant que Claude écrit du code, seul le script d'audit cesse de fonctionner. Le skill reste utile, il perd sa vérification a posteriori.