### PR TITLE
Mettre la page publique au niveau du dépôt, passer en 1.4.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "green-claude",
   "description": "Éco-conception de services numériques (RGESN 2024 / GR491 / Green Software Foundation) appliquée pendant que Claude Code écrit ou revoit du code, avec un audit déterministe et des pratiques d'usage sobre inspirées de Boris Cherny. Présentation : https://institut-du-numerique-responsable.github.io/green-claude/",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "author": {
     "name": "Institut du Numérique Responsable"
   },

--- a/docs/index.html
+++ b/docs/index.html
@@ -32,7 +32,7 @@
     "name": "Green Claude",
     "applicationCategory": "DeveloperApplication",
     "operatingSystem": "macOS, Linux",
-    "softwareVersion": "1.3.0",
+    "softwareVersion": "1.4.0",
     "description": "Skill pour Claude Code : sobriété numérique du code produit (RGESN 2024, GR491, Green Software Foundation, W3C Web Sustainability Guidelines), installé une fois et appliqué automatiquement.",
     "license": "https://opensource.org/licenses/MIT",
     "url": "https://github.com/Institut-du-Numerique-Responsable/green-claude",
@@ -128,6 +128,14 @@
       <h3>Sur demande, un audit</h3>
       <p>« Audit éco-conception de ce fichier » lance un script déterministe (grep sur les règles), zéro coût de raisonnement, qui détecte les motifs contraires à l'éco-conception (SELECT *, bibliothèques lourdes, autoplay…).</p>
     </div>
+    <div class="card">
+      <h3>Le détail de ton langage</h3>
+      <p>80 règles propres à Python, SQL, JavaScript/TypeScript, Java, C#, PHP, Ruby, Rust, C et C++. Une requête N+1 se corrige avec <code>select_related</code> en Django et <code>JOIN FETCH</code> en JPA : l'audit sait lequel te concerne, d'après l'extension du fichier.</p>
+    </div>
+    <div class="card">
+      <h3>À chaque écriture, sans y penser</h3>
+      <p>Un hook optionnel relance l'audit après chaque fichier écrit par Claude Code, sans passer par une décision du modèle. Charger un skill dépend du modèle ; exécuter un hook, non.</p>
+    </div>
   </div>
 
   <h2>Exemple concret</h2>
@@ -153,23 +161,28 @@ app.get('/api/users', (req, res) => {
   <pre><code>/plugin marketplace add Institut-du-Numerique-Responsable/green-claude
 /plugin install green-claude@green-claude</code></pre>
   <p>Rien d'autre à faire : Claude Code charge le skill automatiquement dans les sessions suivantes et gère ses mises à jour. Tape <code>/green-claude</code> pour voir la checklist complète.</p>
-  <p>Alternative via <code>install.sh</code> (nécessaire pour câbler en plus le hook de cache local) :</p>
+  <p>Alternative via <code>install.sh</code>, nécessaire pour câbler en plus les hooks (audit après écriture, cache local) :</p>
   <pre><code>git clone https://github.com/Institut-du-Numerique-Responsable/green-claude.git
 cd green-claude && ./install.sh</code></pre>
+  <p>Pour <strong>Claude.ai</strong> et l'<strong>API Skills</strong>, qui attendent une archive plutôt qu'un dépôt, <code>scripts/package-skill.sh</code> fabrique les deux zips attendus.</p>
 
   <h2>Ce que contient le projet</h2>
   <ul>
     <li>Un skill Claude Code qui s'invoque tout seul dès qu'il s'agit d'écrire ou de revoir du code.</li>
     <li>52 règles d'éco-conception couvrant les 9 familles du <a href="https://ecoresponsable.numerique.gouv.fr/publications/referentiel-general-ecoconception/">RGESN 2024</a>, dont l'Algorithmie et l'IA frugale, reliées au <a href="https://gr491.isit-europe.org/">GR491</a>, avec des règles complémentaires sourcées du <a href="https://w3c.github.io/sustainableweb-wsg/">W3C Web Sustainability Guidelines</a> et des seuils repris de <a href="https://github.com/YellowLabTools/YellowLabTools">YellowLabTools</a>.</li>
+    <li>80 règles propres à un langage (Python, SQL, JavaScript/TypeScript, Java, C#, PHP, Ruby, Rust, C, C++), chargées seulement quand un fichier de ce langage est en jeu.</li>
     <li>14 pratiques de sobriété inspirées de Boris Cherny, le créateur de Claude Code : chacune est sourcée et expliquée.</li>
-    <li>Un hook optionnel pour le cache local des réponses et un avertissement aux heures de pointe, proposé à l'installation, jamais imposé.</li>
+    <li>Des hooks optionnels, proposés à l'installation et jamais imposés : audit après chaque écriture de code, audit avant commit, cache local des réponses, avertissement aux heures de pointe.</li>
+    <li>Un score de densité (<code>eco-score.sh</code>) pour suivre l'évolution d'un dépôt dans le temps, et une intégration continue qui vérifie les règles à chaque contribution.</li>
   </ul>
 
   <h2>Pourquoi c'est important</h2>
   <p>Le code généré par l'IA va tourner pendant des années chez des utilisateurs qu'on ne verra jamais. C'est là que se joue l'essentiel de l'empreinte du « coder avec l'IA », pas pendant la session de génération. Green Claude s'attaque à ce moment précis, en s'appuyant sur des référentiels publics français et internationaux plutôt que sur des règles maison.</p>
 
   <h2>Pourquoi un skill, pas une checklist</h2>
-  <p>Une checklist RGESN en PDF dépend de la mémoire de qui l'a lue une fois, et personne ne la rouvre avant chaque ligne de code. Un skill Claude Code se charge à chaque session sans rappel, sélectionne les familles de règles pertinentes pour ce qui s'écrit à l'instant plutôt que d'imposer les 66 règles à chaque échange, et vérifie le code déjà produit sur demande via un script déterministe. La checklist reste un document consulté ; le skill s'exécute dans la session de travail elle-même.</p>
+  <p>Une checklist RGESN en PDF dépend de la mémoire de qui l'a lue une fois, et personne ne la rouvre avant chaque ligne de code. Un skill Claude Code se charge à chaque session sans rappel, sélectionne les règles pertinentes pour ce qui s'écrit à l'instant plutôt que d'imposer les 146 règles à chaque échange, et vérifie le code déjà produit via un script déterministe. La checklist reste un document consulté ; le skill s'exécute dans la session de travail elle-même.</p>
+
+  <p>Reste que charger un skill est une décision du modèle. Pour les équipes qui veulent une vérification qui ne dépende de personne, le hook d'audit s'exécute après chaque écriture de fichier de code et renvoie ses trouvailles à Claude, qui corrige avant de continuer.</p>
 
   <footer>
     <p>Une production de l'<strong>Institut du Numérique Responsable</strong>, 2026, open source (MIT).<br>

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://institut-du-numerique-responsable.github.io/green-claude/</loc>
-    <lastmod>2026-08-01</lastmod>
+    <lastmod>2026-08-03</lastmod>
     <changefreq>monthly</changefreq>
     <priority>1.0</priority>
   </url>

--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,8 @@
 # =============================================================================
 # Green Claude — Installation
 # Installe le skill éco-conception dans ~/.claude/skills/green-claude
-# et propose le hook de cache/heures creuses (~/.claude/hooks/).
+# et propose les hooks optionnels : audit après écriture, cache local et
+# avertissement aux heures creuses (~/.claude/hooks/).
 # =============================================================================
 
 set -e

--- a/skills/green-claude/SKILL.md
+++ b/skills/green-claude/SKILL.md
@@ -9,7 +9,7 @@ description: |
   code", "écoconception"), or when invoked via /green-claude to walk through the
   rule checklist.
 author: Institut du Numérique Responsable
-version: 1.3.0
+version: 1.4.0
 license: MIT
 user-invocable: true
 ---


### PR DESCRIPTION
## Ce qui était périmé

Les README ont suivi les six PR du jour, la page de présentation non. Elle décrivait encore le projet d'avant :

| Fonctionnalité livrée aujourd'hui | Citée sur le site |
|---|---|
| 80 règles par langage | non |
| Hook d'audit après écriture | non |
| Score de densité et CI | non |
| Installation dans Claude.ai et via l'API | non |
| Décompte des règles | « 66 règles », le vrai total est 146 |

C'est la première page que voit quelqu'un qui découvre le projet. La laisser en arrière est plus coûteux qu'un README en retard.

## Ce que ça change

- Deux cartes ajoutées : les règles par langage, et l'audit relancé après chaque écriture.
- Les canaux d'installation par archive (Claude.ai, API Skills) apparaissent à côté du plugin Claude Code.
- La liste du contenu mentionne les quatre hooks, le score de densité et l'intégration continue.
- Un paragraphe distingue le skill, chargé sur décision du modèle, du hook qui ne dépend de personne.
- Décompte corrigé : 146 règles, soit 52 transverses + 80 par langage + 14 pratiques Boris. Vérifié par `jq` sur les fichiers eux-mêmes, pas recopié.

## Version 1.4.0

Portée aux trois endroits qui la déclarent : `plugin.json`, `SKILL.md` et le JSON-LD de la page. Règles par langage, hook d'audit, score et empaquetage sont des ajouts fonctionnels, pas des correctifs.

## Deux détails au passage

L'en-tête d'`install.sh` n'annonçait que le hook de cache alors que le script en propose trois désormais. Et la date du sitemap datait du 1ᵉʳ août.