### PR TITLE
Exclusions par balise et polices déclarées sur une seule ligne

### DIFF
--- a/skills/green-claude/scripts/eco-audit.sh
+++ b/skills/green-claude/scripts/eco-audit.sh
@@ -76,15 +76,21 @@ strip_markup_text() {
             line = substr(line, 1, RSTART - 1) " " substr(line, RSTART + RLENGTH)
         }
         if (match(line, /<!--/)) { line = substr(line, 1, RSTART - 1); incomment = 1 }
+        # Une balise par ligne. Les exclusions de motif (exclude_patterns)
+        # portent sur la ligne, donc deux balises voisines se couvraient
+        # mutuellement : <img src="photo.jpg"><img src="ok.webp"> faisait taire
+        # la regle sur le JPG parce que le WebP occupait la meme ligne, alors
+        # que ce sont deux images distinctes dont une seule pose probleme.
+        # (Sans apostrophe ni accent : ce bloc awk vit entre quotes simples.)
         out = ""
         n = length(line)
         for (i = 1; i <= n; i++) {
             c = substr(line, i, 1)
             if (c == "<") intag = 1
             if (intag) out = out c
-            if (c == ">") { intag = 0; out = out " " }
+            if (c == ">") { intag = 0; print out; out = "" }
         }
-        print out
+        if (out != "") print out
     }' "$1"
 }
 

--- a/skills/green-claude/scripts/inspect-fonts.sh
+++ b/skills/green-claude/scripts/inspect-fonts.sh
@@ -102,7 +102,17 @@ $pending_family"
             pending_family=""
         fi
     fi
-done < "$FILE"
+# Le parcours est ligne à ligne, et l'entrée dans un @font-face consomme le
+# reste de sa ligne. Un bloc écrit d'un seul tenant — `@font-face { font-family:
+# "A"; src: url("a.woff2"); }`, ce que produit tout minifieur CSS — passait donc
+# entièrement inaperçu. On découpe d'abord sur les accolades et les
+# points-virgules pour retomber sur la forme multi-lignes que la boucle sait
+# lire, sans rien changer à sa logique.
+done < <(sed -e 's/{/{\
+/g' -e 's/;/;\
+/g' -e 's/}/\
+}\
+/g' "$FILE")
 
 nb_familles=$(printf '%s\n' "$families" | sort -u | grep -c . || true)
 nb_autres=$(printf '%s\n' "$families_autres" | sort -u | grep -c . || true)

--- a/skills/green-claude/scripts/test-eco-audit.sh
+++ b/skills/green-claude/scripts/test-eco-audit.sh
@@ -661,4 +661,45 @@ true
 MANQUANTES=$(jq -s -r '[.[].categories[].rules[] | select(.exclude_file_patterns) | select((.note // "") == "") | .id] | join(", ")' ../rules/langages/*.json)
 [ -z "$MANQUANTES" ] || fail "règles avec exclude_file_patterns sans note : $MANQUANTES"
 
+# Exclusions par balise : elles portent sur la ligne, or deux balises voisines
+# partagent souvent la leur. Une image déjà optimisée ne doit pas couvrir celle
+# qui ne l'est pas, même collée à elle dans le source.
+cat > "$TMP/voisines.html" <<'EOF'
+<img src="photo.jpg"><img src="ok.webp">
+EOF
+OUT="$(bash eco-audit.sh "$TMP/voisines.html")"
+echo "$OUT" | grep -q 'ECO-CONT-01' || fail "image non optimisée masquée par une image WebP voisine sur la même ligne"
+
+# L'inverse tient toujours : une balise réellement conforme reste silencieuse.
+cat > "$TMP/conforme.html" <<'EOF'
+<img src="ok.webp" srcset="ok.webp 1x" loading="lazy">
+EOF
+OUT="$(bash eco-audit.sh "$TMP/conforme.html")"
+echo "$OUT" | grep -q 'ECO-CONT-01' && fail "faux positif : image déjà servie en WebP avec srcset"
+true
+
+# @font-face écrit d'un seul tenant, ce que produit tout minifieur CSS : le
+# parcours ligne à ligne consommait le reste de la ligne en entrant dans le
+# bloc, et le fichier entier passait inaperçu.
+python3 -c "
+import os
+for n in 'abc': open(os.path.join('$TMP', n + '.woff2'), 'wb').write(b'\\0' * 20000)
+"
+cat > "$TMP/minifie.css" <<'EOF'
+@font-face { font-family: "A"; src: url("a.woff2"); }
+@font-face { font-family: "B"; src: url("b.woff2"); }
+@font-face { font-family: "C"; src: url("c.woff2"); }
+EOF
+OUT="$(bash eco-audit.sh "$TMP/minifie.css")"
+echo "$OUT" | grep -q 'ECO-UX-05' || fail "trois familles sur une seule ligne : dépassement de seuil non détecté"
+
+# Et sous le seuil, toujours rien à dire, quel que soit le formatage.
+cat > "$TMP/deux-familles.css" <<'EOF'
+@font-face { font-family: "A"; src: url("a.woff2"); }
+@font-face { font-family: "B"; src: url("b.woff2"); }
+EOF
+OUT="$(bash eco-audit.sh "$TMP/deux-familles.css")"
+echo "$OUT" | grep -q 'ECO-UX-05' && fail "faux positif : deux familles restent sous le seuil RGESN 4.8"
+true
+
 echo "OK - suite complete"


### PR DESCRIPTION
Deux limites repérées en relisant #35, laissées de côté parce qu'elles ne relevaient pas de son périmètre.

## 1. Les exclusions se faisaient couvrir entre balises voisines

`exclude_patterns` porte sur la ligne. Or deux balises partagent souvent la leur :

```html
<img src="photo.jpg"><img src="ok.webp">
```

Le `.webp` excluait la ligne entière, donc le JPG non optimisé passait. Sur deux lignes distinctes, il était bien signalé : le résultat dépendait de la mise en forme du source, pas du code.

Le nettoyage des pages de balisage émet maintenant **une balise par ligne**. Chaque image est jugée sur ses propres attributs.

| Cas | Avant | Après |
|---|---|---|
| `<img src="photo.jpg"><img src="ok.webp">` | muet | signalé |
| `<img src="ok.webp" srcset="ok.webp 1x" loading="lazy">` | muet | muet |
| `<video autoplay src="v.mp4">` | signalé | signalé |
| `<meta property="og:image" content="social.jpg">` | muet | muet |

## 2. Les polices déclarées d'un seul tenant échappaient à l'inspection

`inspect-fonts.sh` lit le CSS ligne à ligne, et entrer dans un `@font-face` consommait le reste de la ligne. Un bloc écrit d'un seul tenant, ce que produit **tout minifieur CSS**, passait entièrement inaperçu :

```css
@font-face { font-family: "A"; src: url("a.woff2"); }
@font-face { font-family: "B"; src: url("b.woff2"); }
@font-face { font-family: "C"; src: url("c.woff2"); }
```

Trois familles là où le RGESN 4.8 en autorise deux, et rien n'était dit. Le même contenu formaté sur plusieurs lignes était correctement signalé.

Le fichier est pré-découpé sur les accolades et les points-virgules pour retomber sur la forme multi-lignes que la boucle sait déjà lire. Sa logique n'a pas bougé.

## Tests

Quatre ajoutés, **chacun vérifié en échec avant son correctif** : sans le premier, `ECHEC: image non optimisée masquée par une image WebP voisine` ; sans le second, silence là où trois familles dépassent le seuil.

## Détail d'implémentation qui a coûté une passe

Le bloc awk de nettoyage vit entre quotes simples dans le script shell. Une apostrophe dans un commentaire français y ferme la chaîne et casse le programme. C'est noté dans le code pour la prochaine fois.