### PR TITLE
docs: renforcer l'appartenance à l'Institut du Numérique Responsable

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,9 @@
+# These are supported funding model platforms
+
+github: Institut-du-Numerique-Responsable
+gitlab: 
+ko_fi: 
+liberapay: institutnr
+open_collective: institut-du-numerique-responsable
+patreon: 
+custom: ['https://institutnr.org/soutenir']

--- a/README.fr.md
+++ b/README.fr.md
@@ -5,6 +5,7 @@
 [![Licence MIT](https://img.shields.io/badge/licence-MIT-green.svg)](LICENSE)
 [![RGESN 2024](https://img.shields.io/badge/RGESN-2024-1b7a4a.svg)](https://ecoresponsable.numerique.gouv.fr/publications/referentiel-general-ecoconception/)
 [![GR491](https://img.shields.io/badge/GR491-r%C3%A9f%C3%A9rentiel-1b7a4a.svg)](https://gr491.isit-europe.org/)
+[![INR](https://img.shields.io/badge/INR-Institut%20du%20Num%C3%A9rique%20Responsable-1b7a4a.svg)](https://institutnr.org)
 [![Release](https://img.shields.io/github/v/release/Institut-du-Numerique-Responsable/green-claude)](https://github.com/Institut-du-Numerique-Responsable/green-claude/releases)
 [![Site](https://img.shields.io/badge/site-green--claude-blue)](https://institut-du-numerique-responsable.github.io/green-claude/)
 [![Dernier commit](https://img.shields.io/github/last-commit/Institut-du-Numerique-Responsable/green-claude)](https://github.com/Institut-du-Numerique-Responsable/green-claude/commits/main)

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![MIT License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![RGESN 2024](https://img.shields.io/badge/RGESN-2024-1b7a4a.svg)](https://ecoresponsable.numerique.gouv.fr/publications/referentiel-general-ecoconception/)
 [![GR491](https://img.shields.io/badge/GR491-reference-1b7a4a.svg)](https://gr491.isit-europe.org/)
+[![INR](https://img.shields.io/badge/INR-Institut%20du%20Num%C3%A9rique%20Responsable-1b7a4a.svg)](https://institutnr.org)
 [![Release](https://img.shields.io/github/v/release/Institut-du-Numerique-Responsable/green-claude)](https://github.com/Institut-du-Numerique-Responsable/green-claude/releases)
 [![Site](https://img.shields.io/badge/site-green--claude-blue)](https://institut-du-numerique-responsable.github.io/green-claude/)
 [![Last commit](https://img.shields.io/github/last-commit/Institut-du-Numerique-Responsable/green-claude)](https://github.com/Institut-du-Numerique-Responsable/green-claude/commits/main)


### PR DESCRIPTION
## Changements

- Ajout d'un badge **INR** dans README.md et README.fr.md pour une meilleure visibilité institutionnelle
- Création de **.github/FUNDING.yml** avec :
  - Lien vers institutnr.org/soutenir
  - Open Collective (institut-du-numerique-responsable)
  - Liberapay (institutnr)
- Renforcement de l'identité de l'INR dans le projet

Signed-off-by: gridboy