### PR TITLE
docs: mettre à jour les README avec les 106 règles et la nouvelle catégorie

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -144,23 +144,24 @@ Le script d'audit a besoin de `bash` et de `jq`. Là où `jq` manque, les règle
 
 ---
 
-## Les règles : 83 règles alignées sur les 9 familles du RGESN 2024
+## Les règles : 106 règles alignées sur les 9 familles du RGESN 2024
 
-[`skills/green-claude/rules/ecoconception.json`](skills/green-claude/rules/ecoconception.json) couvre les **9 familles** du [RGESN 2024](https://www.arcep.fr/mes-demarches-et-services/entreprises/fiches-pratiques/referentiel-general-ecoconception-services-numeriques.html) (78 critères officiels). Chaque règle porte un renvoi RGESN (`rgesn_ref`) et une famille [GR491](https://gr491.isit-europe.org/) (`gr491_famille`).
+[`skills/green-claude/rules/ecoconception.json`](skills/green-claude/rules/ecoconception.json) couvre les **9 familles** du [RGESN 2024](https://www.arcep.fr/mes-demarches-et-services/entreprises/fiches-pratiques/referentiel-general-ecoconception-services-numeriques.html) (78 critères officiels) **et une nouvelle catégorie "Hébergement pour l'IA"**. Chaque règle porte un renvoi RGESN (`rgesn_ref`) et une famille [GR491](https://gr491.isit-europe.org/) (`gr491_famille`).
 
 Précision du renvoi RGESN, en l'état : **18 règles** pointent le critère exact (familles 1 à 4, ex. `4.8`), **33 règles** ne pointent que leur famille (`5.x` à `9.x`) faute d'un mappage encore fait, et une règle relève de la Green Software Foundation plutôt que du RGESN. L'affinage des familles 5 à 9 est un chantier ouvert — le champ dit ce qu'il sait, jamais plus.
 
 | Famille RGESN | Règles | Exemples |
 |---|---|---|
-| 1. Stratégie | 6 | Mesurer avant d'optimiser, données raisonnées, formats ouverts, référent sobriété, sensibilisation, transparence utilisateur |
+| 1. Stratégie | 9 | Mesurer avant d'optimiser, données raisonnées, formats ouverts, référent sobriété, sensibilisation, transparence utilisateur |
 | 2. Spécifications | 5 | Compatibilité anciens terminaux, bas débit, impact des services tiers |
-| 3. Architecture | 5 | Low-tech d'abord, ressources adaptées à la charge, environnements de test sobres, code testé et maintenable |
-| 4. UX/UI | 7 | Pas d'autoplay ni de scroll infini, composants natifs, polices limitées, média le plus sobre, prefers-reduced-motion |
-| 5. Contenus | 2 | Images optimisées, SVG |
-| 6. Frontend | 13 | Pas de bibliothèque lourde, lazy loading, minification, dépendances, pas de code mort, pas de globales implicites, pas de XHR synchrone, DOM sobre, pas d'IDs dupliqués, !important limité, pas de CSS dupliqué, pas de hacks IE legacy, scripts différés |
-| 7. Backend | 4 | SQL optimisé, pools de connexions, complexité, pagination + cache |
-| 8. Hébergement | 6 | Hébergeur sobre, compression HTTP, cache HTTP, HTTPS/TLS, liens cassés |
-| 9. **Algorithmie (dont IA)** | 4 | **Justifier l'IA, dimensionner le modèle, mesurer, alternatives sobres** |
+| 3. Architecture | 11 | Low-tech d'abord, ressources adaptées à la charge, environnements de test sobres, code testé et maintenable |
+| 4. UX/UI | 8 | Pas d'autoplay ni de scroll infini, composants natifs, polices limitées, média le plus sobre, prefers-reduced-motion |
+| 5. Contenus | 3 | Images optimisées, SVG, polices |
+| 6. Frontend | 14 | Pas de bibliothèque lourde, lazy loading, minification, dépendances, pas de code mort, pas de globales implicites, pas de XHR synchrone, DOM sobre, pas d'IDs dupliqués, !important limité, pas de CSS dupliqué, pas de hacks IE legacy, scripts différés |
+| 7. Backend | 13 | SQL optimisé, pools de connexions, complexité, pagination + cache, requêtes N+1 |
+| 8. Hébergement | 12 | Hébergeur sobre, compression HTTP, cache HTTP, HTTPS/TLS, liens cassés |
+| 9. **Algorithmie (dont IA)** | 27 | **Justifier l'IA, dimensionner le modèle, mesurer, alternatives sobres, quantification, batching, streaming** |
+| 10. **Hébergement pour l'IA** | 4 | **GPU optimisés inférence, datacenters verts, inférence CPU, dimensionnement modèle** |
 
 Les règles sans motif détectable (démarche, gouvernance) sont ignorées par l'audit et servent de checklist dans `/green-claude`.
 
@@ -168,7 +169,7 @@ Les règles sans motif détectable (démarche, gouvernance) sont ignorées par l
 
 ## Les règles par langage : 127 règles chargées à la demande
 
-Les 83 règles ci-dessus valent quel que soit le langage. Elles fixent l'objectif sans dire comment l'atteindre en Python ou en Java : « éviter les requêtes N+1 » ne tranche pas entre `select_related`, `JOIN FETCH`, `Include` et `with()`.
+Les 106 règles ci-dessus valent quel que soit le langage. Elles fixent l'objectif sans dire comment l'atteindre en Python ou en Java : « éviter les requêtes N+1 » ne tranche pas entre `select_related`, `JOIN FETCH`, `Include` et `with()`.
 
 [`skills/green-claude/rules/langages/`](skills/green-claude/rules/langages/) descend d'un cran, avec un fichier par langage appliqué **uniquement aux fichiers de ce langage** :
 

--- a/README.md
+++ b/README.md
@@ -142,23 +142,24 @@ The audit script needs `bash` and `jq`. Where `jq` is missing, the rules still a
 
 ---
 
-## The rules: 83 rules aligned with the 9 RGESN 2024 families
+## The rules: 106 rules aligned with the 9 RGESN 2024 families
 
-[`skills/green-claude/rules/ecoconception.json`](skills/green-claude/rules/ecoconception.json) covers all **9 families** of [RGESN 2024](https://www.arcep.fr/mes-demarches-et-services/entreprises/fiches-pratiques/referentiel-general-ecoconception-services-numeriques.html) (78 official criteria). Every rule carries an RGESN reference (`rgesn_ref`) and a [GR491](https://gr491.isit-europe.org/) family (`gr491_famille`).
+[`skills/green-claude/rules/ecoconception.json`](skills/green-claude/rules/ecoconception.json) covers all **9 families** of [RGESN 2024](https://www.arcep.fr/mes-demarches-et-services/entreprises/fiches-pratiques/referentiel-general-ecoconception-services-numeriques.html) (78 official criteria) **plus a new "Hosting for AI" category**. Every rule carries an RGESN reference (`rgesn_ref`) and a [GR491](https://gr491.isit-europe.org/) family (`gr491_famille`).
 
 How precise that reference currently is: **18 rules** point at the exact criterion (families 1 to 4, e.g. `4.8`), **33 rules** only point at their family (`5.x` to `9.x`) because that mapping has not been done yet, and one rule follows the Green Software Foundation rather than the RGESN. Refining families 5 to 9 is open work — the field states what it knows, never more.
 
 | RGESN family | Rules | Examples |
 |---|---|---|
-| 1. Strategy | 6 | Measure before optimizing, reasoned data collection, open formats, sustainability advocate, awareness training, user transparency |
+| 1. Strategy | 9 | Measure before optimizing, reasoned data collection, open formats, sustainability advocate, awareness training, user transparency |
 | 2. Specifications | 5 | Compatibility with old devices, low bandwidth, third-party services impact |
-| 3. Architecture | 5 | Low-tech first, resources matched to load, sober test environments, tested and maintainable code |
-| 4. UX/UI | 7 | No autoplay or infinite scroll, native components, limited fonts, most sober medium, prefers-reduced-motion |
-| 5. Content | 2 | Optimized images, SVG |
-| 6. Frontend | 13 | No heavy libraries, lazy loading, minification, dependencies, no dead code, no implicit globals, no synchronous XHR, lean DOM, no duplicate IDs, limited `!important`, no duplicate CSS, no legacy IE hacks, deferred scripts |
-| 7. Backend | 4 | Optimized SQL, connection pools, complexity, pagination + cache |
-| 8. Hosting | 6 | Sober hosting, HTTP compression, HTTP cache, HTTPS/TLS, broken links |
-| 9. **Algorithms (incl. AI)** | 4 | **Justify AI use, right-size the model, measure, sober alternatives** |
+| 3. Architecture | 11 | Low-tech first, resources matched to load, sober test environments, tested and maintainable code |
+| 4. UX/UI | 8 | No autoplay or infinite scroll, native components, limited fonts, most sober medium, prefers-reduced-motion |
+| 5. Content | 3 | Optimized images, SVG, fonts |
+| 6. Frontend | 14 | No heavy libraries, lazy loading, minification, dependencies, no dead code, no implicit globals, no synchronous XHR, lean DOM, no duplicate IDs, limited `!important`, no duplicate CSS, no legacy IE hacks, deferred scripts |
+| 7. Backend | 13 | Optimized SQL, connection pools, complexity, pagination + cache, N+1 queries |
+| 8. Hosting | 12 | Sober hosting, HTTP compression, HTTP cache, HTTPS/TLS, broken links |
+| 9. **Algorithms (incl. AI)** | 27 | **Justify AI use, right-size the model, measure, sober alternatives, quantification, batching, streaming** |
+| 10. **Hosting for AI** | 4 | **Inference-optimized GPUs, green datacenters, CPU inference, model sizing** |
 
 Rules with no detectable pattern (process, governance) are skipped by the audit and serve as a checklist in `/green-claude`.
 
@@ -166,7 +167,7 @@ Rules with no detectable pattern (process, governance) are skipped by the audit 
 
 ## Language rules: 127 rules loaded on demand
 
-The 83 rules above hold whatever the language. They set the goal without saying how to reach it in Python or in Java: "avoid N+1 queries" doesn't choose between `select_related`, `JOIN FETCH`, `Include` and `with()`.
+The 106 rules above hold whatever the language. They set the goal without saying how to reach it in Python or in Java: "avoid N+1 queries" doesn't choose between `select_related`, `JOIN FETCH`, `Include` and `with()`.
 
 [`skills/green-claude/rules/langages/`](skills/green-claude/rules/langages/) goes one level down, with one file per language, applied **only to files of that language**:
 


### PR DESCRIPTION
Mise à jour des fichiers README.md et README.fr.md pour refléter :

- **Nombre total de règles** : 83 → 106 (+23)
- **Nouvelle catégorie** : Hébergement pour l'IA (Hosting for AI) avec 4 règles
- **Mise à jour des comptes par famille RGESN** (ex: Algorithms passe de 4 à 27 règles)
- **Mise à jour des exemples** dans les tableaux

Signed-off-by: gridboy