### PR TITLE
fix: corrige les règles IA ajoutées et réaligne la documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,19 @@ nouvelles versions suivent [Semantic Versioning](https://semver.org/lang/fr/).
 
 ### Corrigé
 
+- Règles IA ajoutées après coup : `ECO-ALGO-09`, `10` et `11` partageaient les mêmes motifs et signalaient trois fois en impact élevé tout fichier important PyTorch, sans décrire un seul défaut de son code. Une seule garde une détection, et elle détecte l'absence d'instrumentation de mesure.
+- `batch_size = 1` attrapait `batch_size = 16`, `128` et `1024` : le motif n'était pas ancré.
+- `ECO-ALGO-25` se déclenchait sur toute fonction nommée `train` ; les motifs nomment désormais les API de fine-tuning.
+- `ECO-ALGO-12` recommandait de quantifier `gpt-4` et `claude-3-opus`, que personne consommant une API ne peut quantifier ; la règle est recadrée sur le chargement d'un modèle auto-hébergé.
+- `ECO-HOST-07` et `08` se déclenchaient tous deux sur `A100` en disant presque la même chose.
+- `ECO-HOST-09` affirmait sans source que `us-east-1` est carboné et une liste de régions européennes propre, et doublait `ECO-HEB-09`.
+- Huit règles portaient `exclude_patterns` et `extensions` sans aucun motif : ces champs ne sont jamais lus.
+- Vingt-et-un motifs utilisaient `\s`, hors ERE POSIX, là où le reste du dépôt utilise `[[:space:]]`.
+- `ECO-HOST-07..10` renumérotées en `ECO-HOST-01..04` : deux règles numérotées `07` coexistaient avec `ECO-HEB`.
+- Comptes de règles réalignés : `SKILL.md` annonçait 83 transverses et 225 au total pour 106 et 248 réelles, et c'est le fichier que le modèle charge. Un test compare désormais les chiffres annoncés aux règles présentes.
+- Documentation : le hook de cadrage, le registre de décisions et le fichier d'exclusion n'étaient décrits nulle part hors du skill ; `CONTRIBUTING.md` ne documentait ni `example`, ni `three_u`, ni `source_note`, ni l'interdiction de `\s` et des lookaheads.
+
+
 - `grep` prenait un motif d’exclusion commençant par `--` pour une option : la règle échouait en silence, ce qui ressemble à un fichier propre.
 - `set -o pipefail` combiné à `grep -q` produisait des faux négatifs sur les fichiers assez gros pour remplir le tube, donc précisément là où il y a le plus à trouver.
 - Résolution d’extension d’un fichier sans point : `Dockerfile` n’était jamais routé vers ses règles.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,12 +26,25 @@ Les règles vivent dans `skills/green-claude/rules/ecoconception.json`, organis�
   "description": "What the rule checks and why it matters.",
   "impact": "High",
   "patterns": ["my_regex_pattern"],
+  "exclude_patterns": ["already_applies_the_practice"],
   "recommendation": "What to do instead.",
+  "example": {
+    "bad":  "the faulty form, one or two lines",
+    "good": "the corrected form, same shape"
+  },
+  "note": "What the pattern cannot see, and what a hit does not prove.",
   "rgesn_ref": "N.x",
   "gr491_famille": "Nom de la famille GR491",
+  "three_u": ["useful"],
   "tags": ["keywords"]
 }
 ```
+
+- `example` (facultatif, vivement recommandé sur les règles à impact élevé) : `bad` et `good`, une ou deux lignes chacun. L'audit affiche `good` sous `Write`. Une recommandation en prose oblige à reconstruire la forme attendue à chaque signalement ; l'exemple l'évite. Un test échoue si une règle transverse à impact élevé et détectable n'en porte pas.
+- `three_u` (facultatif) : à quel volet du cadre 3U de l'INR la règle répond, parmi `useful`, `usable` et `used`. Un service n'est sobre que s'il est utile, utilisable et utilisé, et les trois se tiennent : un service utile que personne ne peut utiliser n'est pas utilisé. C'est la grille de la revue de conception, avant qu'une ligne existe.
+- `source_note` (obligatoire si la règle est adaptée d'un autre projet) : nommer le projet, la règle d'origine et sa licence. Green Codex est en CC BY 4.0, donc l'attribution est due, et un test vérifie qu'elle ne disparaît pas.
+
+**Le texte des règles s'écrit en anglais**, motifs en ERE POSIX. Pas de `\s` ni de lookahead : `grep -E` ne les connaît pas partout, la négation vit dans `exclude_patterns`. Une règle sans `patterns` ni `detector` est une checklist : lui donner des `exclude_patterns` ou des `extensions` ne sert à rien, ils ne seront jamais lus, et un test le refuse.
 
 - `patterns` : expressions régulières `grep -E` qui détectent le problème dans le code. Une liste vide fait de la règle une checklist de démarche/gouvernance, ignorée par l'audit automatique — sauf si un `detector` est défini (voir ci-dessous).
 - `detector` (optionnel) : nom d'un détecteur dédié dans `scripts/detect-<nom>.awk`, pour les cas que grep ne peut pas voir car répartis sur plusieurs lignes (ex. `nested_loops` pour les boucles imbriquées). N'utilisez ce mécanisme que si `patterns` ne peut vraiment pas suffire.

--- a/README.fr.md
+++ b/README.fr.md
@@ -153,7 +153,7 @@ Le script d'audit a besoin de `bash` et de `jq`. Là où `jq` manque, les règle
 
 [`skills/green-claude/rules/ecoconception.json`](skills/green-claude/rules/ecoconception.json) couvre les **9 familles** du [RGESN 2024](https://www.arcep.fr/mes-demarches-et-services/entreprises/fiches-pratiques/referentiel-general-ecoconception-services-numeriques.html) (78 critères officiels) **et une nouvelle catégorie "Hébergement pour l'IA"**. Chaque règle porte un renvoi RGESN (`rgesn_ref`) et une famille [GR491](https://gr491.isit-europe.org/) (`gr491_famille`).
 
-Précision du renvoi RGESN, en l'état : **18 règles** pointent le critère exact (familles 1 à 4, ex. `4.8`), **33 règles** ne pointent que leur famille (`5.x` à `9.x`) faute d'un mappage encore fait, et une règle relève de la Green Software Foundation plutôt que du RGESN. L'affinage des familles 5 à 9 est un chantier ouvert — le champ dit ce qu'il sait, jamais plus.
+Précision du renvoi RGESN, en l'état : **38 règles** pointent le critère exact (familles 1 à 4, ex. `4.8`), **67 règles** ne pointent que leur famille (`5.x` à `9.x`) faute d'un mappage encore fait, et une règle relève de la Green Software Foundation plutôt que du RGESN. L'affinage des familles 5 à 9 est un chantier ouvert — le champ dit ce qu'il sait, jamais plus.
 
 | Famille RGESN | Règles | Exemples |
 |---|---|---|
@@ -243,11 +243,36 @@ Détail complet : [`skills/green-claude/rules/usage.json`](skills/green-claude/r
 
 ## Ce qu'un skill ne peut pas faire (et comment on le couvre quand même)
 
-Un skill s'exécute *pendant* une session déjà lancée, et c'est le modèle qui décide de l'appliquer. Il ne choisit donc pas le modèle de démarrage, n'intercepte pas un appel avant qu'il parte, et ne garantit pas qu'une règle soit vérifiée à tous les coups. Trois leviers restent hors du skill, dans [`hooks/`](hooks/), optionnels et proposés à l'installation :
+Un skill s'exécute *pendant* une session déjà lancée, et c'est le modèle qui décide de l'appliquer. Il ne choisit donc pas le modèle de démarrage, n'intercepte pas un appel avant qu'il parte, et ne garantit pas qu'une règle soit vérifiée à tous les coups. Quatre leviers restent hors du skill, dans [`hooks/`](hooks/), optionnels et proposés à l'installation :
 
 - **Audit systématique** (`hooks/green-claude-audit.sh`) : câblé en `PostToolUse` sur `Write|Edit|MultiEdit`. Claude Code l'exécute après chaque écriture de fichier de code, sans demander son avis au modèle. Le hook audite ce qui vient d'être ajouté et renvoie les motifs trouvés à Claude, qui corrige avant de continuer.
 - **Cache local** (`hooks/green-claude-cache.sh`) : une question déjà posée est resservie sans réappeler le modèle, zéro token consommé.
 - **Avertissement heures creuses** (même hook) : signale les heures de pointe (hors 22h-6h UTC) sans bloquer.
+- **Cadrage avant écriture** (`hooks/green-claude-brief.sh`) : câblé en `UserPromptSubmit`. Sur une demande de production de code, il rappelle les trois règles qui décident de ce qui sera écrit — le moins de code qui résout le problème, challenger la demande et le modèle, poser la question avant de coder. Sur une question, il se tait. Ces règles vivent aussi dans le skill, mais un skill est lu au chargement de la session : trois tours plus tard il ne pèse plus rien.
+
+## Deux fichiers pour faire taire ce qui n'a pas à parler
+
+Un candidat écarté une fois revient au tour suivant, et à celui d'après. Écarté six fois, il apprend à toute l'équipe à survoler l'audit, ce qui coûte plus cher que la règle ne rapporte. Deux fichiers versionnés règlent la question, à la racine du dépôt.
+
+`.green-claude/decisions.md` porte ce que l'équipe a tranché :
+
+```
+ECO-CONT-01  docs/index.html  ACCEPTED  logo.jpg gardé comme repli og:image
+ECO-SH-05    install.sh       TODO      deux mktemp sans trap
+```
+
+`ACCEPTED` fait taire cette règle pour ce fichier, et seulement pour lui. `TODO` reste visible : une dette assumée n'est pas une exemption. L'audit annonce combien de constats il a tus et où se trouve le fichier, donc rien ne disparaît sans trace. Le reste du fichier est de la prose libre, seules les lignes au bon format sont lues.
+
+`.green-claude/ignore` sort des fichiers du périmètre, un motif par ligne :
+
+```
+skills/green-claude/scripts/test-eco-audit.sh
+skills/green-claude/rules/
+```
+
+Une suite de tests et un corpus de règles **contiennent** du code fautif sans jamais l'exécuter. Les signaler est un faux positif par construction, et c'est celui qui a produit le plus de bruit pendant l'écriture de ce dépôt.
+
+Les deux emplacements se surchargent par `GREEN_CLAUDE_DECISIONS` et `GREEN_CLAUDE_IGNORE`.
 
 Ces hooks se câblent dans `~/.claude/settings.json`. Si on répond « o », `install.sh` les y ajoute (les autres réglages sont préservés et une sauvegarde du fichier d'origine est laissée en `settings.json.green-claude.bak`). Sans `jq` il affiche la config à coller à la main. Pour les retirer : supprimer les entrées `green-claude-*` du fichier.
 

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ The audit script needs `bash` and `jq`. Where `jq` is missing, the rules still a
 
 [`skills/green-claude/rules/ecoconception.json`](skills/green-claude/rules/ecoconception.json) covers all **9 families** of [RGESN 2024](https://www.arcep.fr/mes-demarches-et-services/entreprises/fiches-pratiques/referentiel-general-ecoconception-services-numeriques.html) (78 official criteria) **plus a new "Hosting for AI" category**. Every rule carries an RGESN reference (`rgesn_ref`) and a [GR491](https://gr491.isit-europe.org/) family (`gr491_famille`).
 
-How precise that reference currently is: **18 rules** point at the exact criterion (families 1 to 4, e.g. `4.8`), **33 rules** only point at their family (`5.x` to `9.x`) because that mapping has not been done yet, and one rule follows the Green Software Foundation rather than the RGESN. Refining families 5 to 9 is open work — the field states what it knows, never more.
+How precise that reference currently is: **38 rules** point at the exact criterion (families 1 to 4, e.g. `4.8`), **67 rules** only point at their family (`5.x` to `9.x`) because that mapping has not been done yet, and one rule follows the Green Software Foundation rather than the RGESN. Refining families 5 to 9 is open work — the field states what it knows, never more.
 
 | RGESN family | Rules | Examples |
 |---|---|---|
@@ -241,11 +241,36 @@ Full detail: [`skills/green-claude/rules/usage.json`](skills/green-claude/rules/
 
 ## What a skill can't do (and how it's covered anyway)
 
-A skill runs *during* a session that's already started, and the model decides whether to apply it. So it can't pick the starting model, can't intercept a call before it leaves, and can't guarantee a rule gets checked every single time. Three levers therefore live outside the skill, in [`hooks/`](hooks/), optional and offered at install time:
+A skill runs *during* a session that's already started, and the model decides whether to apply it. So it can't pick the starting model, can't intercept a call before it leaves, and can't guarantee a rule gets checked every single time. Four levers therefore live outside the skill, in [`hooks/`](hooks/), optional and offered at install time:
 
 - **Systematic audit** (`hooks/green-claude-audit.sh`): wired as `PostToolUse` on `Write|Edit|MultiEdit`. Claude Code runs it after every code file written, without asking the model. It audits what was just added and hands the findings back to Claude, who fixes them before moving on.
 - **Local cache** (`hooks/green-claude-cache.sh`): a question already asked gets served again without calling the model — zero tokens spent.
 - **Off-peak warning** (same hook): flags peak hours (outside 22:00-06:00 UTC) without ever blocking.
+- **Framing before writing** (`hooks/green-claude-brief.sh`): wired as `UserPromptSubmit`. On a request to produce code, it recalls the three rules that decide what gets written at all — the least code that solves the problem, challenge the request and the model, ask before you build. On a question, it stays quiet. Those rules also live in the skill, but a skill is read when the session loads: three turns later it weighs nothing.
+
+## Two files that silence what should not speak
+
+A candidate you dismiss once comes back on the next run, and the one after that. Dismissed six times, it teaches the whole team to skim past the audit, which costs more than the rule ever saved. Two versioned files close the question, at the repository root.
+
+`.green-claude/decisions.md` holds what the team has settled:
+
+```
+ECO-CONT-01  docs/index.html  ACCEPTED  logo.jpg kept as the og:image fallback
+ECO-SH-05    install.sh       TODO      two mktemp with no trap
+```
+
+`ACCEPTED` silences that rule for that file, and only there. `TODO` stays visible: a debt taken on deliberately is not an exemption. The audit reports how many findings it hid and where the file lives, so nothing vanishes without a trace. The rest of the file is free prose; only lines in the right shape are read.
+
+`.green-claude/ignore` takes files out of scope, one pattern per line:
+
+```
+skills/green-claude/scripts/test-eco-audit.sh
+skills/green-claude/rules/
+```
+
+A test suite and a rule corpus **contain** faulty code without ever running it. Flagging them is a false positive by construction, and it produced more noise than anything else while this repository was written.
+
+Both locations can be overridden with `GREEN_CLAUDE_DECISIONS` and `GREEN_CLAUDE_IGNORE`.
 
 These hooks wire into `~/.claude/settings.json`. If you answer "y", `install.sh` adds them there (other settings are preserved, and a backup of the original file is left at `settings.json.green-claude.bak`). Without `jq`, it prints the config to paste in by hand. To remove them: delete the `green-claude-*` entries from the file.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -212,7 +212,7 @@
   <div class="duo">
     <div class="card">
       <h3>Pendant que Claude code</h3>
-      <p>83 règles d'éco-conception alignées sur les 9 familles du RGESN 2024 : renvoi au critère officiel près pour les familles 1 à 4, renvoi à la famille pour les suivantes. Claude les applique de lui-même en écrivant du code, sans qu'on le lui demande à chaque fois.</p>
+      <p>106 règles d'éco-conception alignées sur les 9 familles du RGESN 2024 : renvoi au critère officiel près pour les familles 1 à 4, renvoi à la famille pour les suivantes. Claude les applique de lui-même en écrivant du code, sans qu'on le lui demande à chaque fois.</p>
     </div>
     <div class="card">
       <h3>Sur demande, un audit</h3>
@@ -271,18 +271,21 @@ cd green-claude && ./install.sh</code></pre>
   <h2>Ce que contient le projet</h2>
   <ul>
     <li>Un skill Claude Code qui s'invoque tout seul dès qu'il s'agit d'écrire ou de revoir du code.</li>
-    <li>83 règles d'éco-conception couvrant les 9 familles du <a href="https://ecoresponsable.numerique.gouv.fr/publications/referentiel-general-ecoconception/">RGESN 2024</a>, dont l'Algorithmie et l'IA frugale, reliées au <a href="https://gr491.isit-europe.org/">GR491</a>, avec des règles complémentaires sourcées du <a href="https://w3c.github.io/sustainableweb-wsg/">W3C Web Sustainability Guidelines</a> et des seuils repris de <a href="https://github.com/YellowLabTools/YellowLabTools">YellowLabTools</a>.</li>
+    <li>106 règles d'éco-conception couvrant les 9 familles du <a href="https://ecoresponsable.numerique.gouv.fr/publications/referentiel-general-ecoconception/">RGESN 2024</a>, dont l'Algorithmie et l'IA frugale, reliées au <a href="https://gr491.isit-europe.org/">GR491</a>, avec des règles complémentaires sourcées du <a href="https://w3c.github.io/sustainableweb-wsg/">W3C Web Sustainability Guidelines</a> et des seuils repris de <a href="https://github.com/YellowLabTools/YellowLabTools">YellowLabTools</a>.</li>
     <li>127 règles propres à un langage (Python, SQL, JavaScript/TypeScript, Java, C#, PHP, Ruby, Rust, C, C++), chargées seulement quand un fichier de ce langage est en jeu.</li>
     <li>15 pratiques d’usage responsable maintenues par le projet, sans attribution personnelle non vérifiée.</li>
-    <li>Des hooks optionnels, proposés à l'installation et jamais imposés : audit après chaque écriture de code, audit avant commit, cache local des réponses, avertissement aux heures de pointe.</li>
+    <li>Des hooks optionnels, proposés à l'installation et jamais imposés : cadrage avant écriture, audit après chaque écriture de code, audit avant commit, cache local des réponses, avertissement aux heures de pointe.</li>
     <li>Un score de densité (<code>eco-score.sh</code>) pour suivre l'évolution d'un dépôt dans le temps, et une intégration continue qui vérifie les règles à chaque contribution.</li>
   </ul>
 
   <h2>Pourquoi c'est important</h2>
   <p>Le code généré par l'IA va tourner pendant des années chez des utilisateurs qu'on ne verra jamais. C'est là que se joue l'essentiel de l'empreinte du « coder avec l'IA », pas pendant la session de génération. Green Claude s'attaque à ce moment précis, en s'appuyant sur des référentiels publics français et internationaux plutôt que sur des règles maison.</p>
 
-  <h2>Pourquoi un skill, pas une checklist</h2>
-  <p>Une checklist RGESN en PDF dépend de la mémoire de qui l'a lue une fois, et personne ne la rouvre avant chaque ligne de code. Un skill Claude Code se charge à chaque session sans rappel, sélectionne les règles pertinentes pour ce qui s'écrit à l'instant plutôt que d'imposer les 225 règles à chaque échange, et vérifie le code déjà produit via un script déterministe. La checklist reste un document consulté ; le skill s'exécute dans la session de travail elle-même.</p>
+    <h2>Ce que l'équipe décide, l'audit s'en souvient</h2>
+  <p>Un candidat écarté une fois revient au tour suivant. Écarté six fois, il apprend à toute l'équipe à survoler l'audit, ce qui coûte plus cher que la règle ne rapporte. Deux fichiers versionnés à la racine du dépôt ferment la question : <code>.green-claude/decisions.md</code> pour ce qui a été tranché, où <code>ACCEPTED</code> fait taire une règle sur un fichier précis et <code>TODO</code> garde la dette visible, et <code>.green-claude/ignore</code> pour les fichiers hors périmètre, comme une suite de tests ou un corpus de règles qui contiennent du code fautif sans jamais l'exécuter. L'audit annonce combien de constats il a tus et où, donc rien ne disparaît sans trace.</p>
+
+<h2>Pourquoi un skill, pas une checklist</h2>
+  <p>Une checklist RGESN en PDF dépend de la mémoire de qui l'a lue une fois, et personne ne la rouvre avant chaque ligne de code. Un skill Claude Code se charge à chaque session sans rappel, sélectionne les règles pertinentes pour ce qui s'écrit à l'instant plutôt que d'imposer les 248 règles à chaque échange, et vérifie le code déjà produit via un script déterministe. La checklist reste un document consulté ; le skill s'exécute dans la session de travail elle-même.</p>
 
   <p>Reste que charger un skill est une décision du modèle. Pour les équipes qui veulent une vérification qui ne dépende de personne, le hook d'audit s'exécute après chaque écriture de fichier de code et renvoie ses trouvailles à Claude, qui corrige avant de continuer.</p>
 

--- a/skills/green-claude/SKILL.md
+++ b/skills/green-claude/SKILL.md
@@ -29,7 +29,7 @@ model, which costs computation and the energy behind it. After the session, the
 code you leave behind runs on every user's machine, on every request, for years.
 Both matter; only one of them stops when the conversation does.
 
-Three rule sets: `rules/ecoconception.json` (83 rules, RGESN 2024 / GR491 /
+Three rule sets: `rules/ecoconception.json` (106 rules, RGESN 2024 / GR491 /
 Green Software Foundation / W3C WSG) while you write or modify code,
 `rules/langages/*.json` (127 rules across 24 languages and frameworks) for the language you're
 working in, and `rules/usage.json` (15 responsible-use practices) during the
@@ -131,7 +131,7 @@ outcome the user must never be handed.
 
 `bash "$SKILL_DIR/scripts/eco-audit.sh" file1 file2 ...` is a deterministic
 script (grep/awk) with no reasoning cost for detection. Run it rather than
-grepping by hand: it carries 225 rules, their thresholds, their per-language
+grepping by hand: it carries 248 rules, their thresholds, their per-language
 scoping and their known false positives, none of which a hand-written grep
 reproduces. Interpret and prioritize its output (High impact first), and read
 *Common mistakes* below before relaying a result as-is.

--- a/skills/green-claude/rules/ecoconception.json
+++ b/skills/green-claude/rules/ecoconception.json
@@ -290,9 +290,9 @@
           "description": "A heavy framework for a brochure site means JavaScript downloaded, parsed and executed by every visitor for nothing.",
           "impact": "High",
           "patterns": [
-            "from\\s+['\"](react|react-dom|vue|@angular/[a-z]+|next)['\"]",
-            "require\\(\\s*['\"](react|react-dom|vue|@angular/[a-z]+|next)['\"]",
-            "\"(react|react-dom|vue|@angular/core|next|nuxt)\"\\s*:\\s*['\"]?[\\^~0-9]"
+            "from[[:space:]]+['\"](react|react-dom|vue|@angular/[a-z]+|next)['\"]",
+            "require\\([[:space:]]*['\"](react|react-dom|vue|@angular/[a-z]+|next)['\"]",
+            "\"(react|react-dom|vue|@angular/core|next|nuxt)\"[[:space:]]*:[[:space:]]*['\"]?[\\^~0-9]"
           ],
           "recommendation": "Before adopting a framework, check whether static HTML/CSS, vanilla JS or HTMX would meet the real need.",
           "example": {
@@ -579,7 +579,7 @@
           "impact": "High",
           "patterns": [
             "<(video|audio|iframe)[^>]*autoplay",
-            "autoplay\\s*[=:]",
+            "autoplay[[:space:]]*[=:]",
             "autoPlay"
           ],
           "recommendation": "Replace autoplay with a clickable cover image (a facade); load the media only on click.",
@@ -792,15 +792,15 @@
             "\\.webp",
             "\\.avif",
             "srcset",
-            "loading\\s*=\\s*[\"']lazy",
-            "type\\s*=\\s*[\"']image/(webp|avif)",
+            "loading[[:space:]]*=[[:space:]]*[\"']lazy",
+            "type[[:space:]]*=[[:space:]]*[\"']image/(webp|avif)",
             "og:image",
             "twitter:image",
-            "rel\\s*=\\s*[\"']icon",
+            "rel[[:space:]]*=[[:space:]]*[\"']icon",
             "apple-touch-icon",
-            "rel\\s*=\\s*[\"']manifest",
-            "\"logo\"\\s*:",
-            "\"image\"\\s*:"
+            "rel[[:space:]]*=[[:space:]]*[\"']manifest",
+            "\"logo\"[[:space:]]*:",
+            "\"image\"[[:space:]]*:"
           ],
           "enrich": "image",
           "enrich_note": "A pattern cannot tell whether an image is already compressed or correctly sized. scripts/inspect-image.sh resolves the real file when it can (not a remote URL) and adds its actual weight and dimensions to the report, asserting nothing when the file cannot be resolved.",
@@ -1017,7 +1017,7 @@
           "description": "A synchronous XMLHttpRequest (third argument of .open() set to false) freezes the main thread until the network responds: nothing else runs, page rendering included.",
           "impact": "High",
           "patterns": [
-            "\\.open\\([^,]+,[^,]+,\\s*false\\s*\\)"
+            "\\.open\\([^,]+,[^,]+,[[:space:]]*false[[:space:]]*\\)"
           ],
           "recommendation": "Use fetch() or an asynchronous XHR (true, the default). There is no legitimate frontend use case for it today.",
           "example": {
@@ -1134,8 +1134,8 @@
           "description": "Hacks targeting old Internet Explorer versions (star html, the \\9 escape) add CSS weight for browsers that now account for a minute share of traffic, when they account for any at all.",
           "impact": "Low",
           "patterns": [
-            "\\*\\s+html\\b",
-            "\\\\9\\s*;"
+            "\\*[[:space:]]+html\\b",
+            "\\\\9[[:space:]]*;"
           ],
           "recommendation": "Check your actual audience statistics before keeping these hacks; remove them when IE6/7/8 support is no longer a justified need.",
           "rgesn_ref": "6.x",
@@ -1218,8 +1218,8 @@
           "description": "SELECT *, functions inside WHERE clauses and random ordering make the database work far beyond the need.",
           "impact": "High",
           "patterns": [
-            "SELECT\\s+\\*",
-            "WHERE\\s+1\\s*=\\s*1",
+            "SELECT[[:space:]]+\\*",
+            "WHERE[[:space:]]+1[[:space:]]*=[[:space:]]*1",
             "ORDER BY.*RAND(OM)?\\(\\)"
           ],
           "recommendation": "Select only the columns you need, index the filtered columns, and avoid functions in WHERE clauses and N+1 queries.",
@@ -1242,11 +1242,11 @@
           "description": "Opening a database connection for every query is costly in CPU and latency, on the application side as much as on the server.",
           "impact": "High",
           "patterns": [
-            "new\\s+[A-Za-z_$][\\w$]*Connection\\s*\\(",
-            "\\bcreateConnection\\s*\\(",
+            "new[[:space:]]+[A-Za-z_$][\\w$]*Connection[[:space:]]*\\(",
+            "\\bcreateConnection[[:space:]]*\\(",
             "\\bpsycopg2\\.connect\\b",
             "\\bDriverManager\\.getConnection\\b",
-            "\\bmysqli_connect\\s*\\("
+            "\\bmysqli_connect[[:space:]]*\\("
           ],
           "recommendation": "Configure a connection pool (pg-pool, HikariCP, mysql2/promise).",
           "example": {
@@ -2175,28 +2175,13 @@
           "title": "Link tokens to physical resources",
           "description": "Tokens are a proxy for computation, but the real impact is in water, electricity, and hardware usage. Without this link, token counts remain abstract.",
           "impact": "High",
-          "patterns": [
-            "import\\s+torch",
-            "import\\s+transformers",
-            "import\\s+tensorflow",
-            "import\\s+keras",
-            "from\\s+torch",
-            "from\\s+transformers",
-            "from\\s+tensorflow",
-            "from\\s+keras"
-          ],
-          "exclude_patterns": [
-            "#.*tokens.*water",
-            "#.*tokens.*electricity",
-            "#.*tokens.*energy",
-            "#.*tokens.*physical"
-          ],
+          "patterns": [],
           "example": {
             "bad": "import torch\nmodel = torch.nn.Transformer()",
             "good": "import torch\n# Link: fewer tokens = less water/electricity consumption\nmodel = torch.nn.Transformer()"
           },
           "recommendation": "State the direction and refuse the ratio. Fewer tokens processed means less computation, and less computation means less energy and water. Exact ratios depend on model, hardware, batching, and datacenter location; measure your setup before claiming figures.",
-          "note": "This rule underpins all AI-specific recommendations: it justifies acting on token counts while prohibiting unverified conversions to watts, joules, or grams of CO2. Patterns detect AI library usage without documented link to physical resources.",
+          "note": "No pattern: whether a team has connected its token counts to physical resources is a property of its documentation and its measurements, not of a line of code. This is a review question.",
           "rgesn_ref": "9.x",
           "gr491_famille": "Backend",
           "tags": [
@@ -2215,21 +2200,7 @@
           "title": "Require real measurements for AI systems",
           "description": "Without actual measurements, you cannot know where the consumption goes, let alone reduce it. Token counts alone are insufficient.",
           "impact": "High",
-          "patterns": [
-            "import\\s+torch",
-            "import\\s+transformers",
-            "import\\s+tensorflow",
-            "import\\s+keras",
-            "from\\s+torch",
-            "from\\s+transformers",
-            "from\\s+tensorflow",
-            "from\\s+keras"
-          ],
-          "exclude_patterns": [
-            "IA_MEASUREMENTS\\.md",
-            "IA_MEASUREMENTS",
-            "#.*measurement"
-          ],
+          "patterns": [],
           "example": {
             "bad": "import torch\n# No measurements",
             "good": "import torch\n# See IA_MEASUREMENTS.md for token count, CPU/GPU time, electricity and water usage"
@@ -2245,34 +2216,25 @@
           ],
           "three_u": [
             "used"
-          ]
+          ],
+          "note": "No pattern: the presence of real measurements is established by reading the measurement report, not by grepping the source. ECO-ALGO-11 detects the absence of instrumentation, which is the part a pattern can see."
         },
         {
           "id": "ECO-ALGO-11",
-          "title": "Set water and electricity budgets",
-          "description": "A budget that only limits tokens does not account for the model size, the hardware, or the datacenter efficiency.",
+          "title": "Measure the energy of an AI workload, do not estimate it",
+          "description": "A training or inference script that loads a framework and measures nothing tells you what it produced and never what it cost. Energy, and the water used to cool the machines that supplied it, are the part nobody sees on a dashboard and the part that grows fastest as the workload scales.",
           "impact": "High",
           "patterns": [
-            "import\\s+torch",
-            "import\\s+transformers",
-            "import\\s+tensorflow",
-            "import\\s+keras",
-            "from\\s+torch",
-            "from\\s+transformers",
-            "from\\s+tensorflow",
-            "from\\s+keras"
-          ],
-          "exclude_patterns": [
-            "water.*budget",
-            "electricity.*budget",
-            "CodeCarbon",
-            "Experiments.*Impact.*Tracker"
+            "import[[:space:]]+torch",
+            "import[[:space:]]+tensorflow",
+            "from[[:space:]]+transformers[[:space:]]+import",
+            "import[[:space:]]+keras"
           ],
           "example": {
             "bad": "import torch\n# No budgets defined",
             "good": "import torch\n# Budgets: < 10L water/day, < 1kWh/day using CodeCarbon"
           },
-          "recommendation": "Define maximum thresholds per project: e.g., < 10L of water/day, < 1kWh/day. Use tools like CodeCarbon or Experiments Impact Tracker to enforce these limits.",
+          "recommendation": "Instrument the run with a measurement library (CodeCarbon, Zeus, carbontracker, or pynvml directly), record the hardware, the duration and the region, and set a budget the job refuses to exceed. Estimate only what you cannot measure, and say which is which.",
           "rgesn_ref": "9.x",
           "gr491_famille": "Backend",
           "tags": [
@@ -2280,29 +2242,30 @@
             "budget",
             "water",
             "electricity"
-          ]
+          ],
+          "exclude_file_patterns": [
+            "codecarbon",
+            "CodeCarbon",
+            "experiment_impact_tracker",
+            "eco2ai",
+            "carbontracker",
+            "pynvml",
+            "nvidia-smi",
+            "zeus",
+            "perun"
+          ],
+          "note": "The rule fires on a file that loads an ML framework and mentions no measurement tooling anywhere. A library module that neither trains nor infers is a false positive; the file that runs the job is the one that should carry the instrumentation."
         },
         {
           "id": "ECO-ALGO-12",
-          "title": "Use quantified models when possible",
-          "description": "Quantized models (int8, int4) reduce memory usage and compute requirements by 4-8x with minimal quality loss.",
+          "title": "Quantise a self-hosted model before buying more hardware",
+          "description": "A model served in full precision uses memory and bandwidth that quantisation often halves for a quality difference the task cannot detect. This applies to what you host yourself: a model served through an API is quantised, or not, by whoever runs it.",
           "impact": "High",
           "patterns": [
-            "model\\s*=\\s*[\"']([^\"']*gpt-4)",
-            "model\\s*=\\s*[\"']([^\"']*claude-3-opus)",
-            "model\\s*=\\s*[\"']([^\"']*llama-2-70b)",
-            "model\\s*=\\s*[\"']([^\"']*mistral-8x7b)"
-          ],
-          "exclude_patterns": [
-            "int8",
-            "int4",
-            "bitsandbytes",
-            "GGML",
-            "ggml",
-            "quantized",
-            "quantization",
-            "\\.gguf",
-            "\\.safetensors"
+            "from_pretrained[[:space:]]*\\(",
+            "AutoModelFor",
+            "\\.half[[:space:]]*\\(\\)",
+            "torch_dtype[[:space:]]*=[[:space:]]*torch\\.float32"
           ],
           "extensions": [
             "py",
@@ -2313,7 +2276,7 @@
             "rs",
             "rb"
           ],
-          "recommendation": "Prefer int8/int4 quantified versions (e.g., 'mistral-7b-instruct-v0.1-int4') to reduce memory and compute by 4-8x. Use libraries like bitsandbytes or GGML.",
+          "recommendation": "Measure quality, latency and memory before and after quantisation on your own test set, then keep the smallest representation that clears the bar. INT8 is not automatically better; it is automatically worth measuring.",
           "example": {
             "bad": "model = 'mistral-7b-instruct-v0.1'",
             "good": "model = 'mistral-7b-instruct-v0.1-int4'"
@@ -2328,7 +2291,19 @@
           ],
           "three_u": [
             "useful"
-          ]
+          ],
+          "exclude_file_patterns": [
+            "int8",
+            "int4",
+            "bitsandbytes",
+            "gguf",
+            "GGML",
+            "quantiz",
+            "awq",
+            "gptq",
+            "onnx"
+          ],
+          "note": "Scoped to loading a self-hosted model. The earlier version flagged the strings gpt-4 and claude-3-opus and recommended quantising them, which nobody consuming an API can do."
         },
         {
           "id": "ECO-ALGO-13",
@@ -2336,13 +2311,12 @@
           "description": "Single requests underutilize GPUs. Batching maximizes throughput and reduces overhead.",
           "impact": "High",
           "patterns": [
-            "batch_size\\s*=\\s*1",
-            "batch_size=1",
-            "max_batch_size\\s*=\\s*1"
+            "batch_size[[:space:]]*=[[:space:]]*1[[:space:]]*($|[,)}#])",
+            "max_batch_size[[:space:]]*=[[:space:]]*1[[:space:]]*($|[,)}#])"
           ],
           "exclude_patterns": [
-            "batch_size\\s*>\\s*1",
-            "max_batch_size\\s*>\\s*1"
+            "batch_size[[:space:]]*>[[:space:]]*1",
+            "max_batch_size[[:space:]]*>[[:space:]]*1"
           ],
           "extensions": [
             "py",
@@ -2366,7 +2340,8 @@
           ],
           "three_u": [
             "useful"
-          ]
+          ],
+          "note": "The pattern is anchored on the value: without the trailing boundary it matched batch_size = 16, 128 and 1024. A batch of one is legitimate for latency-critical inference, so the question is whether throughput or latency governs here."
         },
         {
           "id": "ECO-ALGO-14",
@@ -2374,16 +2349,6 @@
           "description": "Streaming releases the GPU between tokens, reducing memory pressure.",
           "impact": "Medium",
           "patterns": [],
-          "exclude_patterns": [
-            "stream\\s*=\\s*True",
-            "stream=True",
-            "streaming\\s*=\\s*True"
-          ],
-          "extensions": [
-            "py",
-            "js",
-            "ts"
-          ],
           "recommendation": "Enable streaming (stream=True) for long generations to free GPU memory between tokens.",
           "example": {
             "bad": "response = client.generate(prompt)",
@@ -2404,7 +2369,7 @@
           "description": "Recomputing embeddings for the same documents wastes CPU/GPU cycles.",
           "impact": "High",
           "patterns": [
-            "embed\\s*\\("
+            "embed[[:space:]]*\\("
           ],
           "exclude_patterns": [
             "cache",
@@ -2444,16 +2409,6 @@
           "description": "Recomputing the same prompts increases latency and energy consumption.",
           "impact": "High",
           "patterns": [],
-          "exclude_patterns": [
-            "cache_prompt",
-            "prompt_cache",
-            "cached_prompt"
-          ],
-          "extensions": [
-            "py",
-            "js",
-            "ts"
-          ],
           "recommendation": "Enable prompt caching (cache_prompt=True) to avoid recomputing identical prompts.",
           "rgesn_ref": "9.x",
           "gr491_famille": "Backend",
@@ -2508,15 +2463,6 @@
           "description": "Tokenization, decoding, and post-processing can run on CPU, freeing GPU.",
           "impact": "Medium",
           "patterns": [],
-          "exclude_patterns": [
-            "device\\s*=\\s*\\\"cpu\\\"",
-            "to\\s*\\\\('cpu'\\\""
-          ],
-          "extensions": [
-            "py",
-            "js",
-            "ts"
-          ],
           "recommendation": "Move tokenization, decoding, and post-processing to CPU to free GPU resources.",
           "rgesn_ref": "9.x",
           "gr491_famille": "Backend",
@@ -2584,16 +2530,6 @@
           "description": "Unbounded memory leads to swapping, multiplying energy by 10x.",
           "impact": "Medium",
           "patterns": [],
-          "exclude_patterns": [
-            "max_memory",
-            "max_ram",
-            "memory_limit"
-          ],
-          "extensions": [
-            "py",
-            "js",
-            "ts"
-          ],
           "recommendation": "Configure max_memory or max_ram to prevent swapping (e.g., max_memory=8GiB in vLLM).",
           "rgesn_ref": "8.x",
           "gr491_famille": "Hébergement",
@@ -2610,16 +2546,6 @@
           "description": "High GPU temperatures increase energy consumption and reduce lifespan.",
           "impact": "Medium",
           "patterns": [],
-          "exclude_patterns": [
-            "nvidia-smi",
-            "TEMPERATURE",
-            "gpu_temp",
-            "thermal"
-          ],
-          "extensions": [
-            "py",
-            "sh"
-          ],
           "recommendation": "Stop tasks if GPU temperature exceeds 80C. Monitor with nvidia-smi -q -d TEMPERATURE.",
           "rgesn_ref": "8.x",
           "gr491_famille": "Hébergement",
@@ -2636,14 +2562,6 @@
           "description": "Swapping to disk multiplies energy consumption by 10x.",
           "impact": "High",
           "patterns": [],
-          "exclude_patterns": [
-            "swappiness",
-            "vm\\.swappiness"
-          ],
-          "extensions": [
-            "sh",
-            "py"
-          ],
           "recommendation": "Set swappiness=10 and monitor swap usage with free -h.",
           "rgesn_ref": "8.x",
           "gr491_famille": "Hébergement",
@@ -2660,10 +2578,12 @@
           "description": "Fine-tuning consumes orders of magnitude more than inference. Often RAG suffices.",
           "impact": "High",
           "patterns": [
-            "\\.fine_tune\\s*\\\"",
+            "fine_tune",
             "FineTuningJob",
-            "train\\s*\\(",
-            "trainer\\s*="
+            "Trainer[[:space:]]*\\(",
+            "\\.fit[[:space:]]*\\(",
+            "peft",
+            "LoraConfig"
           ],
           "exclude_patterns": [
             "# No fine-tuning",
@@ -2692,7 +2612,8 @@
           "example": {
             "bad": "trainer = Trainer(model=base_model)\ntrainer.fine_tune(dataset)",
             "good": "# Use RAG instead of fine-tuning for knowledge updates\nvector_store = FAISS.from_documents(documents)\nretriever = vector_store.as_retriever()"
-          }
+          },
+          "note": "A bare train() call was matching any function named train, so the patterns now name the fine-tuning APIs. Fine-tuning is the right answer when the task needs a behaviour the base model does not have; it is the wrong one when the task needs knowledge, which retrieval supplies without a training run."
         },
         {
           "id": "ECO-ALGO-26",
@@ -2700,16 +2621,6 @@
           "description": "Training on unfiltered datasets wastes compute on irrelevant or duplicate data.",
           "impact": "High",
           "patterns": [],
-          "exclude_patterns": [
-            "deduplicate",
-            "filter",
-            "prune",
-            "clean",
-            "dataset\\.filter"
-          ],
-          "extensions": [
-            "py"
-          ],
           "recommendation": "Reduce dataset size by: (1) deduplicating, (2) filtering irrelevant examples, (3) sampling.",
           "rgesn_ref": "3.1",
           "gr491_famille": "Architecture",
@@ -2729,19 +2640,6 @@
           "description": "RAG adds knowledge without retraining, saving massive compute.",
           "impact": "High",
           "patterns": [],
-          "exclude_patterns": [
-            "RAG",
-            "retrieval",
-            "RetrievalAugmented",
-            "vector_store",
-            "FAISS",
-            "faiss"
-          ],
-          "extensions": [
-            "py",
-            "js",
-            "ts"
-          ],
           "recommendation": "For adding knowledge, use RAG (Retrieval-Augmented Generation) instead of fine-tuning. It's cheaper, faster, and dynamically updatable.",
           "rgesn_ref": "3.1",
           "gr491_famille": "Architecture",
@@ -2762,20 +2660,16 @@
       "description": "Rules for choosing energy-efficient hardware, datacenters, and deployment strategies for AI workloads.",
       "rules": [
         {
-          "id": "ECO-HOST-07",
-          "title": "Prefer inference-optimized GPUs",
-          "description": "Inference-optimized GPUs (e.g., NVIDIA L40S, T4) consume 40% less power than training GPUs (A100, H100).",
+          "id": "ECO-HOST-01",
+          "title": "Size the accelerator to the workload",
+          "description": "A training-class accelerator running inference spends most of its power idle between requests, because the memory bandwidth it was built for is not what inference needs. The gap shows up as a utilisation figure nobody looks at and an energy bill everybody pays.",
           "impact": "High",
           "patterns": [
             "A100",
             "H100",
-            "V100"
-          ],
-          "exclude_patterns": [
-            "L40S",
-            "T4",
-            "L4",
-            "inference"
+            "V100",
+            "MI300",
+            "TPU[[:space:]]*v[45]"
           ],
           "extensions": [
             "py",
@@ -2783,7 +2677,7 @@
             "yaml",
             "yml"
           ],
-          "recommendation": "Use NVIDIA L40S or T4 for inference tasks; they consume 40% less power. Benchmark with MLPerf Inference.",
+          "recommendation": "Measure utilisation and latency on the actual workload before choosing the class. Inference-oriented parts (L4, L40S, T4, Inferentia) often serve the same traffic for less power; training-class parts earn their cost when the job actually saturates them.",
           "rgesn_ref": "8.x",
           "gr491_famille": "Hébergement",
           "tags": [
@@ -2798,29 +2692,23 @@
           "example": {
             "bad": "gpu_type = \"A100\"  # For inference workload",
             "good": "gpu_type = \"L40S\"  # Inference-optimized, 40% less power"
-          }
+          },
+          "exclude_file_patterns": [
+            "utilization",
+            "utilisation",
+            "nvidia-smi",
+            "dcgm",
+            "profil"
+          ],
+          "note": "Naming a training-class accelerator is the candidate, not the defect: the same part is the right answer for a job that saturates it. A file that already reports utilisation stays silent."
         },
         {
-          "id": "ECO-HOST-08",
-          "title": "Avoid oversized GPUs for small tasks",
-          "description": "Using A100/H100 for models < 10B parameters wastes energy.",
+          "id": "ECO-HOST-02",
+          "title": "Justify accelerator capacity with a utilisation measurement",
+          "description": "Capacity is usually chosen once, from what was available or what a benchmark suggested, and then never revisited. A machine at fifteen percent utilisation draws most of its idle power for nothing, and the fix is a smaller instance rather than a better model.",
           "impact": "High",
-          "patterns": [
-            "A100",
-            "H100"
-          ],
-          "exclude_patterns": [
-            "L40S",
-            "T4",
-            "L4"
-          ],
-          "extensions": [
-            "py",
-            "sh",
-            "yaml",
-            "yml"
-          ],
-          "recommendation": "For models < 10B parameters, use L40S or T4 instead of A100/H100. Use quantified models on lighter GPUs.",
+          "patterns": [],
+          "recommendation": "Record utilisation, memory headroom and queue depth over a representative period, then resize. Scale to zero where the traffic allows it, and prefer several small instances to one idle large one when the workload divides.",
           "rgesn_ref": "8.x",
           "gr491_famille": "Hébergement",
           "tags": [
@@ -2832,32 +2720,16 @@
           "example": {
             "bad": "gpu_type = \"A100\"  # For 7B parameter model",
             "good": "gpu_type = \"T4\"  # Sufficient for models < 10B parameters"
-          }
+          },
+          "note": "No pattern: a utilisation figure lives in monitoring, not in the source. This is a review question."
         },
         {
-          "id": "ECO-HOST-09",
-          "title": "Deploy in green datacenters",
-          "description": "Datacenters vary in energy efficiency and renewable usage.",
+          "id": "ECO-HOST-03",
+          "title": "Place an AI workload where the grid is cleanest, with a source",
+          "description": "Carbon intensity varies by a large factor between regions and across the day, and an accelerator draws enough power for that factor to dominate the footprint of a training run. The region is usually picked for latency or price and never revisited.",
           "impact": "Medium",
-          "patterns": [
-            "us-east-1",
-            "us-west-1"
-          ],
-          "exclude_patterns": [
-            "europe-west1",
-            "europe-west4",
-            "asia-southeast1",
-            "canada-central1",
-            "sweden-central1",
-            "germany-west2"
-          ],
-          "extensions": [
-            "yaml",
-            "yml",
-            "sh",
-            "py"
-          ],
-          "recommendation": "Choose regions with >80% renewable energy and PUE < 1.2. Examples: Google Oregon, AWS Sweden, OVH Gravelines.",
+          "patterns": [],
+          "recommendation": "Compare regions on published grid intensity for the period you will actually run, cite the source and its date, and weigh it against latency, residency and cost. Defer what can wait to a cleaner window. See ECO-HEB-09 for the general case and ECO-HEB-08 for the timing.",
           "rgesn_ref": "8.x",
           "gr491_famille": "Hébergement",
           "tags": [
@@ -2865,25 +2737,15 @@
             "renewable",
             "PUE",
             "energy"
-          ]
+          ],
+          "note": "No pattern: the earlier version flagged us-east-1 and treated a list of European regions as clean. Grid intensity does not divide that way, it changes over time, and the project does not make that kind of claim without a current source."
         },
         {
-          "id": "ECO-HOST-10",
+          "id": "ECO-HOST-04",
           "title": "Use CPU for small models",
           "description": "For models < 1B parameters, CPU inference can be more energy-efficient.",
           "impact": "Medium",
           "patterns": [],
-          "exclude_patterns": [
-            "device\\s*=\\s*\"cpu\"",
-            "device='cpu'",
-            "GGML",
-            "ONNX"
-          ],
-          "extensions": [
-            "py",
-            "sh",
-            "yaml"
-          ],
           "recommendation": "For models < 1B parameters, prefer CPU inference using GGML or ONNX Runtime. CPU reduces power for small workloads.",
           "rgesn_ref": "8.x",
           "gr491_famille": "Hébergement",
@@ -2892,7 +2754,8 @@
             "gpu",
             "inference",
             "energy"
-          ]
+          ],
+          "note": "No pattern: whether a model fits on CPU depends on its size and the latency you owe, neither of which is visible in a line. Measure both paths on the real model before deciding."
         }
       ]
     }

--- a/skills/green-claude/scripts/test-eco-audit.sh
+++ b/skills/green-claude/scripts/test-eco-audit.sh
@@ -1096,4 +1096,100 @@ OUT="$(GREEN_CLAUDE_IGNORE="$TMP/ign/.green-claude/ignore" bash eco-audit.sh "$T
 echo "$OUT" | grep -q 'ECO-SQL-01' && fail "exclusion : un fichier listé est encore audité"
 true
 
+# 45. Comptes annoncés contre comptes réels. Ils ont dérivé trois fois : les
+# README suivaient l'ajout de règles, SKILL.md non, et c'est SKILL.md que le
+# modèle charge. Un skill qui annonce 83 règles quand il en porte 106 se
+# trompe sur lui-même.
+RULES_DIR="../rules"
+COUNT_ECO=$(jq '[.categories[].rules[]] | length' "$RULES_DIR/ecoconception.json")
+COUNT_LANG=$(cat "$RULES_DIR"/langages/*.json | jq -s '[.[].categories[].rules[]] | length')
+COUNT_USAGE=$(jq '[.categories[].rules[]] | length' "$RULES_DIR/usage.json")
+COUNT_TOTAL=$(( COUNT_ECO + COUNT_LANG + COUNT_USAGE ))
+
+grep -q "($COUNT_ECO rules, RGESN 2024" ../SKILL.md \
+    || fail "SKILL.md annonce un nombre de règles transverses qui n'est plus $COUNT_ECO"
+grep -q "it carries $COUNT_TOTAL rules," ../SKILL.md \
+    || fail "SKILL.md annonce un total qui n'est plus $COUNT_TOTAL"
+[ "$COUNT_ECO" = "$(jq -r '.metadata.count' "$RULES_DIR/ecoconception.json")" ] \
+    || fail "ecoconception.json : metadata.count ne correspond plus au nombre de règles"
+[ "$COUNT_USAGE" = "$(jq -r '.metadata.count' "$RULES_DIR/usage.json")" ] \
+    || fail "usage.json : metadata.count ne correspond plus au nombre de règles"
+for lang_json in "$RULES_DIR"/langages/*.json; do
+    declared=$(jq -r '.metadata.count' "$lang_json")
+    actual=$(jq '[.categories[].rules[]] | length' "$lang_json")
+    [ "$declared" = "$actual" ] \
+        || fail "$(basename "$lang_json") : metadata.count vaut $declared pour $actual règles"
+done
+true
+
+# 46. Règles IA et hébergement : chacune de ces corrections vient d'un faux
+# positif constaté, pas d'une relecture. Le volet « code raisonnable » compte
+# donc autant que le volet fautif.
+mkdir -p "$TMP/ia"
+cat > "$TMP/ia/ok.py" <<'PYEOF'
+import torch
+from codecarbon import EmissionsTracker
+tracker = EmissionsTracker()
+loader = DataLoader(ds, batch_size=32)
+PYEOF
+OUT="$(bash eco-audit.sh "$TMP/ia/ok.py")"
+echo "$OUT" | grep -q 'ECO-ALGO-11' && fail "IA : un script instrumenté (CodeCarbon) est signalé comme non mesuré"
+echo "$OUT" | grep -q 'ECO-ALGO-13' && fail "IA : batch_size=32 pris pour batch_size=1"
+true
+
+# batch_size = 1 n'était pas ancré : il attrapait 16, 128, 1024.
+printf 'batch_size = 16\n' > "$TMP/ia/b16.py"
+printf 'batch_size = 1\n'  > "$TMP/ia/b1.py"
+OUT="$(bash eco-audit.sh "$TMP/ia/b16.py")"
+echo "$OUT" | grep -q 'ECO-ALGO-13' && fail "batch_size : 16 signalé comme 1"
+OUT="$(bash eco-audit.sh "$TMP/ia/b1.py")"
+echo "$OUT" | grep -q 'ECO-ALGO-13' || fail "batch_size : la vraie valeur 1 n'est plus détectée"
+true
+
+# Une fonction nommée train n'est pas un entraînement de modèle.
+printf 'def train(model, data):\n    model.step(data)\n' > "$TMP/ia/train.py"
+OUT="$(bash eco-audit.sh "$TMP/ia/train.py")"
+echo "$OUT" | grep -q 'ECO-ALGO-25' && fail "fine-tuning : toute fonction nommée train est signalée"
+printf 'trainer = Trainer(model=m)\n' > "$TMP/ia/ft.py"
+OUT="$(bash eco-audit.sh "$TMP/ia/ft.py")"
+echo "$OUT" | grep -q 'ECO-ALGO-25' || fail "fine-tuning : un Trainer n'est plus détecté"
+true
+
+# Quantifier un modèle servi par API n'a pas de sens : personne ne peut le faire.
+printf 'model = "gpt-4"\nresp = client.chat.completions.create(model=model, max_tokens=256)\n' > "$TMP/ia/api.py"
+OUT="$(bash eco-audit.sh "$TMP/ia/api.py")"
+echo "$OUT" | grep -q 'ECO-ALGO-12' && fail "quantification : recommandée sur un modèle d'API"
+true
+
+# Un accélérateur nommé ne doit pas déclencher deux règles qui disent la même
+# chose, ni une affirmation non sourcée sur le mix électrique d'une région.
+printf 'accelerator: A100\nregion: us-east-1\n' > "$TMP/ia/gpu.yml"
+OUT="$(bash eco-audit.sh "$TMP/ia/gpu.yml")"
+COUNT="$(printf '%s\n' "$OUT" | grep -c 'ECO-HOST-' || true)"
+[ "$COUNT" -le 1 ] || fail "hébergement IA : $COUNT règles se déclenchent sur un seul accélérateur nommé"
+echo "$OUT" | grep -q 'us-east-1 est' && fail "hébergement IA : affirmation non sourcée sur une région"
+true
+
+# Un champ d'exclusion sur une règle sans motif n'est jamais lu : il donne à
+# croire qu'elle détecte quelque chose.
+jq -e '[.categories[].rules[] | select(((.patterns // []) | length == 0) and ((.detector // "") == "") and (((.exclude_patterns // []) | length > 0) or ((.extensions // []) | length > 0)))] | length == 0' \
+    ../rules/ecoconception.json >/dev/null \
+    || fail "des règles sans motif portent des exclusions ou des extensions, qui ne seront jamais lues"
+true
+
+# \s n'est pas du ERE POSIX. Il passe sur les grep GNU et BSD, pas partout.
+jq -e '[.categories[].rules[] | (.patterns // []) + (.exclude_patterns // []) + (.exclude_file_patterns // []) | .[] | select(test("\\\\s"))] | length == 0' \
+    ../rules/ecoconception.json >/dev/null \
+    || fail "un motif utilise \\s au lieu de [[:space:]] : hors ERE POSIX"
+true
+
+# Deux préfixes pour l'hébergement donnaient deux règles numérotées 07.
+jq -e '[.categories[].rules[].id | capture("^(?<p>[A-Z-]+)-(?<n>[0-9]+)$") | .p + "-" + .n] | (length == (unique | length))' \
+    ../rules/ecoconception.json >/dev/null \
+    || fail "identifiants de règles en doublon"
+jq -e '[.categories[].rules[].id | select(startswith("ECO-HOST-"))] | length == 0 or (map(sub("ECO-HOST-";"") | tonumber) | min == 1)' \
+    ../rules/ecoconception.json >/dev/null \
+    || fail "ECO-HOST ne recommence pas à 01 : ses numéros chevauchent ceux d'ECO-HEB"
+true
+
 echo "OK - suite complete"


### PR DESCRIPTION
## Contexte

23 règles IA/hébergement ont été ajoutées après la fusion de #40. Audit et correction de sept défauts, chacun vérifié par un cas de test avant/après.

## Règles corrigées

- **ECO-ALGO-09/10/11** partageaient les mêmes motifs (`import torch`/`transformers`/`tensorflow`) et signalaient trois fois en impact élevé tout fichier ML, sans décrire un seul défaut réel. Une seule garde une détection : l'absence d'instrumentation de mesure (CodeCarbon, Zeus, carbontracker...). Les deux autres deviennent des règles de démarche.
- **`batch_size = 1`** attrapait `16`, `128`, `1024` : motif non ancré.
- **ECO-ALGO-25** se déclenchait sur toute fonction nommée `train` ; les motifs nomment désormais les API de fine-tuning.
- **ECO-ALGO-12** recommandait de quantifier `gpt-4` et `claude-3-opus`, que personne consommant une API ne peut quantifier ; recadrée sur le chargement d'un modèle auto-hébergé.
- **ECO-HOST-07 et 08** se déclenchaient tous deux sur `A100` en disant presque la même chose.
- **ECO-HOST-09** affirmait sans source qu'une région est carbonée et une autre propre, et doublait `ECO-HEB-09` ; devient une règle de démarche qui renvoie vers `ECO-HEB-08/09`.
- **8 règles** portaient `exclude_patterns` et `extensions` sans aucun motif : jamais lus.
- **21 motifs** utilisaient `\s`, hors ERE POSIX ; remplacés par `[[:space:]]`.
- **`ECO-HOST-07..10`** renumérotées en `ECO-HOST-01..04` : deux règles numérotées `07` coexistaient avec `ECO-HEB`. Gratuit maintenant, plus jamais après publication.

## Documentation réalignée

- `SKILL.md` annonçait 83 règles transverses et 225 au total pour 106 et 248 réelles — et c'est le fichier que le modèle charge. `docs/index.html` portait les mêmes chiffres périmés. Un test compare désormais les comptes annoncés aux règles présentes.
- Le hook de cadrage (`green-claude-brief.sh`), le registre de décisions (`.green-claude/decisions.md`) et le fichier d'exclusion (`.green-claude/ignore`) n'étaient documentés nulle part hors du skill ; les deux README les décrivent maintenant.
- `CONTRIBUTING.md` ne documentait ni `example`, ni `three_u`, ni `source_note`, ni l'interdiction de `\s` et des lookaheads.

## Vérification

JSON des 26 fichiers de règles, cohérence des versions, fichiers communautaires, suite de 46 blocs de tests, tests de cache, empaquetage — tous rejoués en local. Version inchangée (1.4.0), entrée `CHANGELOG` en `[Unreleased]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UGPRp9qUn3tnNWwEeH7UMu
