### PR TITLE
fix: motifs \s non-POSIX dans les fichiers de langue

### DIFF
--- a/skills/green-claude/rules/langages/c.json
+++ b/skills/green-claude/rules/langages/c.json
@@ -64,7 +64,7 @@
           "description": "strlen re-evaluated on every iteration walks the whole string again: a quadratic loop invisible on reading.",
           "impact": "High",
           "patterns": [
-            "for\\s*\\([^;]*;[^;]*strlen\\s*\\("
+            "for[[:space:]]*\\([^;]*;[^;]*strlen[[:space:]]*\\("
           ],
           "recommendation": "Compute the length once before the loop.",
           "example": {
@@ -127,7 +127,7 @@
           "description": "A polling loop or a short sleep keeps the CPU core busy and prevents low-power states.",
           "impact": "High",
           "patterns": [
-            "while\\s*\\(\\s*1\\s*\\)",
+            "while[[:space:]]*\\([[:space:]]*1[[:space:]]*\\)",
             "\\busleep\\(",
             "\\bsleep\\("
           ],

--- a/skills/green-claude/rules/langages/cpp.json
+++ b/skills/green-claude/rules/langages/cpp.json
@@ -29,8 +29,8 @@
           "description": "Passing a string or a vector by value copies the entire content on every call.",
           "impact": "Medium",
           "patterns": [
-            "\\(\\s*std::string\\s+\\w+\\s*[,)]",
-            "\\(\\s*std::vector<[^>]*>\\s+\\w+\\s*[,)]"
+            "\\([[:space:]]*std::string[[:space:]]+\\w+[[:space:]]*[,)]",
+            "\\([[:space:]]*std::vector<[^>]*>[[:space:]]+\\w+[[:space:]]*[,)]"
           ],
           "recommendation": "Pass by const&; std::move to transfer ownership; non-owning views (std::string_view, std::span) to read without copying.",
           "rgesn_ref": "9.1",
@@ -123,8 +123,8 @@
           "description": "A polling loop keeps a CPU core busy and prevents low-power states.",
           "impact": "High",
           "patterns": [
-            "while\\s*\\(\\s*true\\s*\\)",
-            "while\\s*\\(\\s*1\\s*\\)"
+            "while[[:space:]]*\\([[:space:]]*true[[:space:]]*\\)",
+            "while[[:space:]]*\\([[:space:]]*1[[:space:]]*\\)"
           ],
           "recommendation": "condition_variable, poll/epoll or async primitives; build production with optimisations and profile before any manual optimisation.",
           "example": {

--- a/skills/green-claude/rules/langages/csharp.json
+++ b/skills/green-claude/rules/langages/csharp.json
@@ -64,7 +64,7 @@
           "description": "Count() walks and counts every row when an existence test can stop at the first one.",
           "impact": "Low",
           "patterns": [
-            "\\.Count\\(\\)\\s*[><=]"
+            "\\.Count\\(\\)[[:space:]]*[><=]"
           ],
           "recommendation": "Any() for an existence test; avoid enumerating the same IEnumerable several times (materialise once when reused).",
           "rgesn_ref": "9.1",
@@ -107,7 +107,7 @@
           "description": "One HttpClient per call exhausts sockets and repeats the TLS handshake on every request.",
           "impact": "Medium",
           "patterns": [
-            "new\\s+HttpClient\\("
+            "new[[:space:]]+HttpClient\\("
           ],
           "recommendation": "IHttpClientFactory (connections reused); enable response compression and cache headers (ResponseCache, ETag).",
           "rgesn_ref": "7.2",
@@ -147,7 +147,7 @@
           "description": "A static Dictionary used as a cache grows without limit until the process restarts.",
           "impact": "Medium",
           "patterns": [
-            "static\\s+(readonly\\s+)?(Dictionary|ConcurrentDictionary)"
+            "static[[:space:]]+(readonly[[:space:]]+)?(Dictionary|ConcurrentDictionary)"
           ],
           "recommendation": "IMemoryCache with SizeLimit/AbsoluteExpiration, or a distributed cache with a TTL.",
           "rgesn_ref": "7.3",
@@ -164,7 +164,7 @@
           "description": "`s += ...` allocates a new string on every iteration: needless GC pressure on hot paths.",
           "impact": "Low",
           "patterns": [
-            "\\+=\\s*\""
+            "\\+=[[:space:]]*\""
           ],
           "recommendation": "StringBuilder for repeated concatenation; Span<T>/Memory<T> for heavy parsing; parameterised structured logging (_logger.LogDebug(\"x={X}\", x)).",
           "rgesn_ref": "9.1",

--- a/skills/green-claude/rules/langages/java.json
+++ b/skills/green-claude/rules/langages/java.json
@@ -25,7 +25,7 @@
           "description": "Loads every row and manages them as managed entities: memory, CPU and network proportional to the table size.",
           "impact": "High",
           "patterns": [
-            "\\.findAll\\(\\s*\\)"
+            "\\.findAll\\([[:space:]]*\\)"
           ],
           "recommendation": "Paginate as a matter of course (Pageable, setMaxResults); process large volumes in chunks.",
           "example": {
@@ -106,7 +106,7 @@
           "description": "`s += ...` allocates a new String on every iteration: needless memory and GC pressure in hot loops.",
           "impact": "Low",
           "patterns": [
-            "\\+=\\s*\""
+            "\\+=[[:space:]]*\""
           ],
           "recommendation": "StringBuilder for repeated concatenation; avoid boxing in pipelines (IntStream rather than Stream<Integer>).",
           "rgesn_ref": "9.1",
@@ -123,7 +123,7 @@
           "description": "A static Map used as a cache grows without limit: memory held until restart, and possibly an OOM.",
           "impact": "Medium",
           "patterns": [
-            "static\\s+(final\\s+)?(Map|HashMap|ConcurrentHashMap)"
+            "static[[:space:]]+(final[[:space:]]+)?(Map|HashMap|ConcurrentHashMap)"
           ],
           "recommendation": "Caffeine with maximumSize plus expireAfterWrite, or an external cache with a TTL.",
           "rgesn_ref": "7.3",

--- a/skills/green-claude/rules/langages/javascript.json
+++ b/skills/green-claude/rules/langages/javascript.json
@@ -30,8 +30,8 @@
           "description": "`import * as x`, or importing a monolithic library such as lodash or moment, defeats tree-shaking: the entire package ends up in the bundle.",
           "impact": "High",
           "patterns": [
-            "import\\s+\\*\\s+as\\s+\\w+\\s+from",
-            "from\\s+['\"](lodash|moment)['\"]",
+            "import[[:space:]]+\\*[[:space:]]+as[[:space:]]+\\w+[[:space:]]+from",
+            "from[[:space:]]+['\"](lodash|moment)['\"]",
             "require\\(['\"](lodash|moment)['\"]\\)"
           ],
           "recommendation": "Targeted imports (import { x } from 'lib/x'); native APIs first (fetch, Intl, URL, structuredClone, Date/Temporal) before adding a dependency.",
@@ -106,7 +106,7 @@
           "description": "scroll, resize, mousemove and input fire dozens of times per second: a costly handler there monopolises the device's CPU.",
           "impact": "Medium",
           "patterns": [
-            "addEventListener\\(\\s*['\"](scroll|resize|mousemove|input|pointermove)['\"]"
+            "addEventListener\\([[:space:]]*['\"](scroll|resize|mousemove|input|pointermove)['\"]"
           ],
           "exclude_file_patterns": [
             "requestAnimationFrame\\(",
@@ -131,7 +131,7 @@
           "description": "includes/indexOf/find inside a loop gives quadratic processing on unbounded collections.",
           "impact": "Medium",
           "patterns": [
-            "for\\s*\\(.*\\)\\s*\\{?.*\\.(includes|indexOf|find)\\("
+            "for[[:space:]]*\\(.*\\)[[:space:]]*\\{?.*\\.(includes|indexOf|find)\\("
           ],
           "recommendation": "Index into a Map or a Set before the loop.",
           "rgesn_ref": "9.1",
@@ -171,7 +171,7 @@
           "description": "A client created for every request repeats DNS resolution and the TLS handshake: latency and CPU paid again each time.",
           "impact": "Medium",
           "patterns": [
-            "new\\s+(HttpClient|XMLHttpRequest)\\(",
+            "new[[:space:]]+(HttpClient|XMLHttpRequest)\\(",
             "axios\\.create\\("
           ],
           "recommendation": "A shared HTTP client with a keep-alive agent; a reused database connection pool.",
@@ -194,7 +194,7 @@
           "exclude_file_patterns": [
             "removeEventListener",
             "AbortController",
-            "\\bsignal\\s*:",
+            "\\bsignal[[:space:]]*:",
             "\\bonUnmounted\\b",
             "\\bngOnDestroy\\b"
           ],

--- a/skills/green-claude/rules/langages/php.json
+++ b/skills/green-claude/rules/langages/php.json
@@ -47,7 +47,7 @@
           "description": "Reading an association inside a foreach fires one query per element.",
           "impact": "High",
           "patterns": [
-            "foreach\\s*\\(\\s*\\$\\w+->"
+            "foreach[[:space:]]*\\([[:space:]]*\\$\\w+->"
           ],
           "recommendation": "Eager loading: with() (Eloquent) or a fetch join / DQL join (Doctrine); project the useful columns rather than full entities.",
           "example": {
@@ -90,7 +90,7 @@
           "impact": "Medium",
           "patterns": [
             "file_get_contents\\(",
-            "\\bfile\\s*\\("
+            "\\bfile[[:space:]]*\\("
           ],
           "recommendation": "Read as a stream (fopen plus block reads), fputcsv and streams for exports; generators (yield) to produce long sequences.",
           "rgesn_ref": "9.2",

--- a/skills/green-claude/rules/langages/python.json
+++ b/skills/green-claude/rules/langages/python.json
@@ -25,7 +25,7 @@
           "description": "Iterating a queryset whose associations you read fires one query per row: network and database cost grow linearly with the volume.",
           "impact": "High",
           "patterns": [
-            "for\\s+\\w+\\s+in\\s+\\w+\\.objects\\.(all|filter)\\("
+            "for[[:space:]]+\\w+[[:space:]]+in[[:space:]]+\\w+\\.objects\\.(all|filter)\\("
           ],
           "recommendation": "Load the associations you walk with select_related/prefetch_related (Django) or joinedload/selectinload (SQLAlchemy).",
           "example": {
@@ -47,7 +47,7 @@
           "impact": "High",
           "patterns": [
             "\\.objects\\.all\\(\\)",
-            "list\\(\\s*\\w+\\.objects\\.",
+            "list\\([[:space:]]*\\w+\\.objects\\.",
             "\\.query\\([^)]*\\)\\.all\\(\\)"
           ],
           "recommendation": "Paginate every exposed list; stream large volumes with iterator() (Django) or yield_per() (SQLAlchemy).",
@@ -124,7 +124,7 @@
           "impact": "High",
           "patterns": [
             "\\.iterrows\\(\\)",
-            "axis\\s*=\\s*1"
+            "axis[[:space:]]*=[[:space:]]*1"
           ],
           "recommendation": "Vectorise with numpy and pandas operations; cut memory with suitable dtypes (category, short integers).",
           "example": {
@@ -145,7 +145,7 @@
           "description": "`s += ...` rebuilds the whole string on every iteration (quadratic behaviour on long sequences).",
           "impact": "Low",
           "patterns": [
-            "\\+=\\s*[\"'f]"
+            "\\+=[[:space:]]*[\"'f]"
           ],
           "recommendation": "Accumulate in a list then ''.join(...), or write straight to a stream.",
           "rgesn_ref": "9.1",
@@ -183,9 +183,9 @@
           "description": "An lru_cache with no maxsize, or a global dict used as a cache, grows without limit: memory held for entries never reused.",
           "impact": "Medium",
           "patterns": [
-            "lru_cache\\(\\s*\\)",
-            "@lru_cache\\s*$",
-            "@cache\\s*$"
+            "lru_cache\\([[:space:]]*\\)",
+            "@lru_cache[[:space:]]*$",
+            "@cache[[:space:]]*$"
           ],
           "recommendation": "Bound and expire every cache: lru_cache(maxsize=N), a TTL on the Redis or Memcached side.",
           "rgesn_ref": "7.3",

--- a/skills/green-claude/rules/langages/ruby.json
+++ b/skills/green-claude/rules/langages/ruby.json
@@ -64,7 +64,7 @@
           "description": "count > 0, or any? on a relation, runs a full count when the database could stop at the first row.",
           "impact": "Low",
           "patterns": [
-            "\\.count\\s*>\\s*0"
+            "\\.count[[:space:]]*>[[:space:]]*0"
           ],
           "recommendation": "exists? for an existence test; update_all/insert_all for bulk writes, never save inside a loop.",
           "rgesn_ref": "9.1",
@@ -102,7 +102,7 @@
           "description": "`s += ...` allocates a new string on every iteration, where mutation reuses the buffer.",
           "impact": "Low",
           "patterns": [
-            "\\+=\\s*['\"]"
+            "\\+=[[:space:]]*['\"]"
           ],
           "recommendation": "Build with << (mutation); lazy enumerators (.lazy) and each_slice for long transformation chains.",
           "rgesn_ref": "9.1",

--- a/skills/green-claude/rules/langages/sql.json
+++ b/skills/green-claude/rules/langages/sql.json
@@ -30,7 +30,7 @@
           "description": "Transfers every column, including the ones never read: network, memory and serialisation wasted, and breakage on the slightest schema change.",
           "impact": "High",
           "patterns": [
-            "select\\s+\\*"
+            "select[[:space:]]+\\*"
           ],
           "recommendation": "List explicitly the columns the need requires.",
           "example": {
@@ -66,8 +66,8 @@
           "description": "A function applied to the filtered column (UPPER, DATE, CAST), or a LIKE '%...' with a leading wildcard, rules out the index: full table scan.",
           "impact": "High",
           "patterns": [
-            "where[^;]*\\b(upper|lower|date|trunc|to_char|cast|convert)\\s*\\(",
-            "like\\s+'%"
+            "where[^;]*\\b(upper|lower|date|trunc|to_char|cast|convert)[[:space:]]*\\(",
+            "like[[:space:]]+'%"
           ],
           "recommendation": "Rewrite the predicate against the raw column (a date range, a direct comparison) or create a dedicated functional index.",
           "example": {
@@ -88,7 +88,7 @@
           "description": "A DISTINCT added to remove duplicates usually hides an incorrect join: the database sorts or hashes the whole result for nothing.",
           "impact": "Medium",
           "patterns": [
-            "\\bselect\\s+distinct\\b"
+            "\\bselect[[:space:]]+distinct\\b"
           ],
           "recommendation": "Check the cardinality of the joins; prefer EXISTS over IN (subquery) on large volumes.",
           "rgesn_ref": "9.1",
@@ -125,7 +125,7 @@
           "impact": "High",
           "patterns": [
             "\\bcursor\\b",
-            "for\\s+\\w+\\s+in\\s*\\(?\\s*select",
+            "for[[:space:]]+\\w+[[:space:]]+in[[:space:]]*\\(?[[:space:]]*select",
             "\\bloop\\b"
           ],
           "recommendation": "UPDATE ... WHERE, INSERT ... SELECT or MERGE in one statement; failing that, BULK COLLECT (with LIMIT) and FORALL in PL/SQL.",
@@ -164,7 +164,7 @@
           "description": "A DELETE with no WHERE and no slicing saturates the journal, holds long locks, and can fail the whole operation.",
           "impact": "Medium",
           "patterns": [
-            "delete\\s+from\\s+[\\w.\"]+\\s*;"
+            "delete[[:space:]]+from[[:space:]]+[\\w.\"]+[[:space:]]*;"
           ],
           "recommendation": "Purge in chunks with pauses; consider TRUNCATE or partitioning where the semantics allow.",
           "rgesn_ref": "7.3",
@@ -204,8 +204,8 @@
           "description": "VARCHAR(MAX) and CLOB \"just in case\" inflate storage, backups and transfers for the whole lifetime of the table.",
           "impact": "Low",
           "patterns": [
-            "varchar\\s*\\(\\s*max",
-            "nvarchar\\s*\\(\\s*max",
+            "varchar[[:space:]]*\\([[:space:]]*max",
+            "nvarchar[[:space:]]*\\([[:space:]]*max",
             "\\bclob\\b"
           ],
           "recommendation": "Size the types to the real need (no BIGINT when INT is enough, no TEXT by default).",


### PR DESCRIPTION
Suite à #46 : le correctif `\s` → `[[:space:]]` n'avait touché que le
fichier en cours de modification, pas les 9 autres fichiers de langue
qui en portaient encore 38.

`CONTRIBUTING.md` interdit désormais `\s` explicitement, donc autant
que ce soit vrai partout.

Détection revérifiée sur 3 cas après correction (N+1 Django, SELECT *,
concaténation JS) : toujours déclenchée.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UGPRp9qUn3tnNWwEeH7UMu
