### PR TITLE
feat: règle sur les commentaires clairs (code, commits, PR)

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -149,7 +149,7 @@ Le script d'audit a besoin de `bash` et de `jq`. Là où `jq` manque, les règle
 
 ---
 
-## Les règles : 106 règles alignées sur les 9 familles du RGESN 2024
+## Les règles : 107 règles alignées sur les 9 familles du RGESN 2024
 
 [`skills/green-claude/rules/ecoconception.json`](skills/green-claude/rules/ecoconception.json) couvre les **9 familles** du [RGESN 2024](https://www.arcep.fr/mes-demarches-et-services/entreprises/fiches-pratiques/referentiel-general-ecoconception-services-numeriques.html) (78 critères officiels) **et une nouvelle catégorie "Hébergement pour l'IA"**. Chaque règle porte un renvoi RGESN (`rgesn_ref`) et une famille [GR491](https://gr491.isit-europe.org/) (`gr491_famille`).
 
@@ -174,7 +174,7 @@ Les règles sans motif détectable (démarche, gouvernance) sont ignorées par l
 
 ## Les règles par langage : 127 règles chargées à la demande
 
-Les 106 règles ci-dessus valent quel que soit le langage. Elles fixent l'objectif sans dire comment l'atteindre en Python ou en Java : « éviter les requêtes N+1 » ne tranche pas entre `select_related`, `JOIN FETCH`, `Include` et `with()`.
+Les 107 règles ci-dessus valent quel que soit le langage. Elles fixent l'objectif sans dire comment l'atteindre en Python ou en Java : « éviter les requêtes N+1 » ne tranche pas entre `select_related`, `JOIN FETCH`, `Include` et `with()`.
 
 [`skills/green-claude/rules/langages/`](skills/green-claude/rules/langages/) descend d'un cran, avec un fichier par langage appliqué **uniquement aux fichiers de ce langage** :
 

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ The audit script needs `bash` and `jq`. Where `jq` is missing, the rules still a
 
 ---
 
-## The rules: 106 rules aligned with the 9 RGESN 2024 families
+## The rules: 107 rules aligned with the 9 RGESN 2024 families
 
 [`skills/green-claude/rules/ecoconception.json`](skills/green-claude/rules/ecoconception.json) covers all **9 families** of [RGESN 2024](https://www.arcep.fr/mes-demarches-et-services/entreprises/fiches-pratiques/referentiel-general-ecoconception-services-numeriques.html) (78 official criteria) **plus a new "Hosting for AI" category**. Every rule carries an RGESN reference (`rgesn_ref`) and a [GR491](https://gr491.isit-europe.org/) family (`gr491_famille`).
 
@@ -172,7 +172,7 @@ Rules with no detectable pattern (process, governance) are skipped by the audit 
 
 ## Language rules: 127 rules loaded on demand
 
-The 106 rules above hold whatever the language. They set the goal without saying how to reach it in Python or in Java: "avoid N+1 queries" doesn't choose between `select_related`, `JOIN FETCH`, `Include` and `with()`.
+The 107 rules above hold whatever the language. They set the goal without saying how to reach it in Python or in Java: "avoid N+1 queries" doesn't choose between `select_related`, `JOIN FETCH`, `Include` and `with()`.
 
 [`skills/green-claude/rules/langages/`](skills/green-claude/rules/langages/) goes one level down, with one file per language, applied **only to files of that language**:
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -212,7 +212,7 @@
   <div class="duo">
     <div class="card">
       <h3>Pendant que Claude code</h3>
-      <p>106 règles d'éco-conception alignées sur les 9 familles du RGESN 2024 : renvoi au critère officiel près pour les familles 1 à 4, renvoi à la famille pour les suivantes. Claude les applique de lui-même en écrivant du code, sans qu'on le lui demande à chaque fois.</p>
+      <p>107 règles d'éco-conception alignées sur les 9 familles du RGESN 2024 : renvoi au critère officiel près pour les familles 1 à 4, renvoi à la famille pour les suivantes. Claude les applique de lui-même en écrivant du code, sans qu'on le lui demande à chaque fois.</p>
     </div>
     <div class="card">
       <h3>Sur demande, un audit</h3>
@@ -271,9 +271,9 @@ cd green-claude && ./install.sh</code></pre>
   <h2>Ce que contient le projet</h2>
   <ul>
     <li>Un skill Claude Code qui s'invoque tout seul dès qu'il s'agit d'écrire ou de revoir du code.</li>
-    <li>106 règles d'éco-conception couvrant les 9 familles du <a href="https://ecoresponsable.numerique.gouv.fr/publications/referentiel-general-ecoconception/">RGESN 2024</a>, dont l'Algorithmie et l'IA frugale, reliées au <a href="https://gr491.isit-europe.org/">GR491</a>, avec des règles complémentaires sourcées du <a href="https://w3c.github.io/sustainableweb-wsg/">W3C Web Sustainability Guidelines</a> et des seuils repris de <a href="https://github.com/YellowLabTools/YellowLabTools">YellowLabTools</a>.</li>
+    <li>107 règles d'éco-conception couvrant les 9 familles du <a href="https://ecoresponsable.numerique.gouv.fr/publications/referentiel-general-ecoconception/">RGESN 2024</a>, dont l'Algorithmie et l'IA frugale, reliées au <a href="https://gr491.isit-europe.org/">GR491</a>, avec des règles complémentaires sourcées du <a href="https://w3c.github.io/sustainableweb-wsg/">W3C Web Sustainability Guidelines</a> et des seuils repris de <a href="https://github.com/YellowLabTools/YellowLabTools">YellowLabTools</a>.</li>
     <li>127 règles propres à un langage (Python, SQL, JavaScript/TypeScript, Java, C#, PHP, Ruby, Rust, C, C++), chargées seulement quand un fichier de ce langage est en jeu.</li>
-    <li>15 pratiques d’usage responsable maintenues par le projet, sans attribution personnelle non vérifiée.</li>
+    <li>16 pratiques d’usage responsable maintenues par le projet, sans attribution personnelle non vérifiée.</li>
     <li>Des hooks optionnels, proposés à l'installation et jamais imposés : cadrage avant écriture, audit après chaque écriture de code, audit avant commit, cache local des réponses, avertissement aux heures de pointe.</li>
     <li>Un score de densité (<code>eco-score.sh</code>) pour suivre l'évolution d'un dépôt dans le temps, et une intégration continue qui vérifie les règles à chaque contribution.</li>
   </ul>
@@ -285,7 +285,7 @@ cd green-claude && ./install.sh</code></pre>
   <p>Un candidat écarté une fois revient au tour suivant. Écarté six fois, il apprend à toute l'équipe à survoler l'audit, ce qui coûte plus cher que la règle ne rapporte. Deux fichiers versionnés à la racine du dépôt ferment la question : <code>.green-claude/decisions.md</code> pour ce qui a été tranché, où <code>ACCEPTED</code> fait taire une règle sur un fichier précis et <code>TODO</code> garde la dette visible, et <code>.green-claude/ignore</code> pour les fichiers hors périmètre, comme une suite de tests ou un corpus de règles qui contiennent du code fautif sans jamais l'exécuter. L'audit annonce combien de constats il a tus et où, donc rien ne disparaît sans trace.</p>
 
 <h2>Pourquoi un skill, pas une checklist</h2>
-  <p>Une checklist RGESN en PDF dépend de la mémoire de qui l'a lue une fois, et personne ne la rouvre avant chaque ligne de code. Un skill Claude Code se charge à chaque session sans rappel, sélectionne les règles pertinentes pour ce qui s'écrit à l'instant plutôt que d'imposer les 248 règles à chaque échange, et vérifie le code déjà produit via un script déterministe. La checklist reste un document consulté ; le skill s'exécute dans la session de travail elle-même.</p>
+  <p>Une checklist RGESN en PDF dépend de la mémoire de qui l'a lue une fois, et personne ne la rouvre avant chaque ligne de code. Un skill Claude Code se charge à chaque session sans rappel, sélectionne les règles pertinentes pour ce qui s'écrit à l'instant plutôt que d'imposer les 250 règles à chaque échange, et vérifie le code déjà produit via un script déterministe. La checklist reste un document consulté ; le skill s'exécute dans la session de travail elle-même.</p>
 
   <p>Reste que charger un skill est une décision du modèle. Pour les équipes qui veulent une vérification qui ne dépende de personne, le hook d'audit s'exécute après chaque écriture de fichier de code et renvoie ses trouvailles à Claude, qui corrige avant de continuer.</p>
 

--- a/skills/green-claude/SKILL.md
+++ b/skills/green-claude/SKILL.md
@@ -29,7 +29,7 @@ model, which costs computation and the energy behind it. After the session, the
 code you leave behind runs on every user's machine, on every request, for years.
 Both matter; only one of them stops when the conversation does.
 
-Three rule sets: `rules/ecoconception.json` (106 rules, RGESN 2024 / GR491 /
+Three rule sets: `rules/ecoconception.json` (107 rules, RGESN 2024 / GR491 /
 Green Software Foundation / W3C WSG) while you write or modify code,
 `rules/langages/*.json` (127 rules across 24 languages and frameworks) for the language you're
 working in, and `rules/usage.json` (15 responsible-use practices) during the
@@ -131,7 +131,7 @@ outcome the user must never be handed.
 
 `bash "$SKILL_DIR/scripts/eco-audit.sh" file1 file2 ...` is a deterministic
 script (grep/awk) with no reasoning cost for detection. Run it rather than
-grepping by hand: it carries 248 rules, their thresholds, their per-language
+grepping by hand: it carries 250 rules, their thresholds, their per-language
 scoping and their known false positives, none of which a hand-written grep
 reproduces. Interpret and prioritize its output (High impact first), and read
 *Common mistakes* below before relaying a result as-is.

--- a/skills/green-claude/rules/ecoconception.json
+++ b/skills/green-claude/rules/ecoconception.json
@@ -10,7 +10,7 @@
       "https://github.com/Institut-du-Numerique-Responsable/green-codex"
     ],
     "coverage_note": "The RGESN 2024 has 78 criteria across 9 families; the GR491 has 61 recommendations and 516 criteria across 8 families. This file selects 52 actionable rules without reproducing the full referential: every RGESN family is represented, and rgesn_ref points at the official criterion for further reading. An rgesn_ref shaped 'N.x' means the rule belongs to family N without matching a single criterion.",
-    "count": 106,
+    "count": 107,
     "type": "code_audit",
     "type_note": "Rules with 'patterns' are found in code by the audit (grep). Rules with 'detector' use a dedicated multi-line detector (scripts/detect-*.awk) where line-by-line grep is not enough. Rules with neither are design or process rules: they serve as a checklist through --list-rules.",
     "three_u_note": "The three_u field marks which of the three conditions of a sober digital service a rule serves, as framed by the Institut du Numerique Responsable: useful (it answers a real need, and that need calls for something digital), usable (by everyone, on modest hardware and constrained networks), used (someone actually uses it, and what nobody uses gets retired). The three hold together: a useful service nobody can use goes unused, and a used service that is not useful consumes for nothing. It is the design-review lens to apply before any code exists; rgesn_ref stays the pointer to the official criterion.",
@@ -564,6 +564,26 @@
             "fan-out",
             "retries",
             "backpressure"
+          ]
+        },
+        {
+          "id": "ECO-ARCH-12",
+          "title": "Write comments a newcomer can follow, not a transcript for yourself",
+          "description": "A comment nobody can parse gets skipped, and code nobody understands gets rewritten rather than fixed. That rewrite repeats work that a clear explanation would have made unnecessary, and it repeats it every time someone new touches the file.",
+          "impact": "Medium",
+          "patterns": [],
+          "recommendation": "Say why the code does something non-obvious, not what it does when the code already says that. Use plain words over jargon, keep sentences short, and update or remove a comment the moment the code it describes changes. The same holds for commit messages and pull request descriptions: they document intent for the next reader, human or model, and a message nobody can follow costs as much as no message at all.",
+          "rgesn_ref": "GSF",
+          "gr491_famille": "Architecture",
+          "three_u": [
+            "used"
+          ],
+          "source_note": "Extends the same Green Software Foundation thesis as ECO-ARCH-05, applied to documentation rather than test coverage: unclear code costs in rework the way untested code does.",
+          "tags": [
+            "comments",
+            "documentation",
+            "readability",
+            "commits"
           ]
         }
       ]

--- a/skills/green-claude/rules/usage.json
+++ b/skills/green-claude/rules/usage.json
@@ -5,7 +5,7 @@
     "version": "3.0.0",
     "editorial_status": "Recommendations of the Green Claude project, not attributed to any individual.",
     "source_policy": "Any attribution to a named person requires a verifiable primary source. Commands and features mentioned here must be checked against the official documentation for the version in use.",
-    "count": 15,
+    "count": 16,
     "type": "practices",
     "type_note": "These rules describe USAGE PRACTICES, not code patterns: they carry no grep-able 'patterns'. The --eco-check audit ignores them; use --list-rules to consult them as a checklist.",
     "energy_claim_policy": "This project states the direction and refuses the ratio. Fewer tokens processed means less computation, and less computation means less energy: that much holds. Converting a token count into watts, joules or grams of CO2 does not, because prompt caching, model size, batching, hardware and the grid mix each move the result more than the token count does. Earlier versions of this file carried such conversions, taken from a secondary source and never measured; they were removed. Keep the qualitative claim, keep the guard: any figure put on this link must come from a measurement of the setup it describes. A test in scripts/test-eco-audit.sh fails if the removed figures return, and this policy is checked alongside them."
@@ -203,6 +203,23 @@
             "skills",
             "commands",
             "reuse"
+          ]
+        },
+        {
+          "id": "USAGE-MEM-03",
+          "title": "Write commit messages and PR descriptions for the next reader",
+          "principle": "A commit or a PR is read far more often than it is written; write it for that reader, not for the moment of writing.",
+          "description": "State what changed and why in plain language, lead with the part a reviewer needs first, and skip the parts that add length without adding understanding. The same applies to a merge: a reviewer approving in a hurry still needs to know what they are approving.",
+          "why_green": "A commit message nobody can follow gets re-explained in a comment thread, or the change gets re-reviewed from the diff alone; both cost more than writing it clearly once. This extends the code-comment discipline to the message that carries the change itself.",
+          "how": "One clear sentence for what changed, one or two for why if it is not obvious from the diff. Name the specific fix or feature, not \"various improvements\". Keep it short: state the point once, plainly, without an admin explaining how thorough they were.",
+          "impact": "Medium",
+          "patterns": [],
+          "source_ref": "Editorial recommendation of the Green Claude project.",
+          "tags": [
+            "commits",
+            "pull-requests",
+            "documentation",
+            "readability"
           ]
         }
       ]


### PR DESCRIPTION
Deux nouvelles règles, demandées explicitement : documenter simplement
et de façon compréhensible, dans le code comme dans les commits et PR.

- **ECO-ARCH-12** (transverse) : commenter pour le prochain lecteur,
  pas pour soi-même. Un commentaire illisible se saute, un code
  incompris se réécrit — coût de rework évitable, dans la même famille
  que ECO-ARCH-05 (qualité de code).
- **USAGE-MEM-03** (pratique d'usage) : même exigence pour les
  messages de commit et les descriptions de PR — clairs, courts,
  qui disent quoi et pourquoi sans remplissage.

Comptes réalignés partout (107 transverses + 127 langage + 16 usage =
250) dans SKILL.md, les deux README et docs/index.html.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UGPRp9qUn3tnNWwEeH7UMu
